### PR TITLE
Fix: luxon-ext type

### DIFF
--- a/packages/luxon-ext/src/index.ts
+++ b/packages/luxon-ext/src/index.ts
@@ -10,7 +10,7 @@ interface ExtendedToHumanDurationOptions {
 }
 
 interface TemporalToHumanDurationOptions extends ExtendedToHumanDurationOptions {
-  formatter: Formatter
+  formatter?: Formatter
 }
 
 type Temporal = 'past' | 'future'


### PR DESCRIPTION
formatter should be optional and use default formatter if not provided.

```diff
 interface TemporalToHumanDurationOptions extends ExtendedToHumanDurationOptions {
-  formatter: Formatter
+  formatter?: Formatter
 }
```
