### PR TITLE
Update CI node version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          # https://nodejs.org/en/about/previous-releases
+          node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 20.x, 21.x]
+        # https://nodejs.org/en/about/previous-releases
+        node-version: [18.x, 20.x, 22.x]
 
     steps:
       - uses: actions/checkout@v4
@@ -47,7 +48,8 @@ jobs:
         run: pnpm pack
 
       - name: Upload coverage to Codecov
-        if: matrix.node-version == '20.x'
+        # https://nodejs.org/en/about/previous-releases
+        if: matrix.node-version == '22.x'
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/typedoc.yml
+++ b/.github/workflows/typedoc.yml
@@ -18,7 +18,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          # https://nodejs.org/en/about/previous-releases
+          node-version: 22.x
 
       - run: pnpm install
 


### PR DESCRIPTION
- Update CI node versions to 18, 20, 22.
  - https://nodejs.org/en/about/previous-releases
  - 22 is the latest LTS version.
