### PR TITLE
Update Node.js version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           # https://nodejs.org/en/about/previous-releases
-          node-version: '22.x'
+          node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         # https://nodejs.org/en/about/previous-releases
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x, 24.x]
 
     steps:
       - uses: actions/checkout@v4
@@ -49,7 +49,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         # https://nodejs.org/en/about/previous-releases
-        if: matrix.node-version == '22.x'
+        if: matrix.node-version == '24.x'
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/typedoc.yml
+++ b/.github/workflows/typedoc.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           # https://nodejs.org/en/about/previous-releases
-          node-version: 22.x
+          node-version: 24.x
 
       - run: pnpm install
 

--- a/package.json
+++ b/package.json
@@ -17,12 +17,12 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
-    "@swc/core": "^1.10.18",
+    "@swc/core": "^1.11.24",
     "@vitest/coverage-v8": "3.1.3",
-    "tsup": "^8.3.6",
-    "typedoc": "^0.28.0",
-    "typescript": "^5.7.3",
-    "vitest": "^3.0.6"
+    "tsup": "^8.5.0",
+    "typedoc": "^0.28.4",
+    "typescript": "^5.8.3",
+    "vitest": "^3.1.3"
   },
   "packageManager": "pnpm@10.11.0"
 }

--- a/packages/incremental-color-palette/package.json
+++ b/packages/incremental-color-palette/package.json
@@ -31,6 +31,6 @@
   "types": "dist/index.d.ts",
   "files": ["dist", "package.json"],
   "devDependencies": {
-    "tsx": "^4.19.3"
+    "tsx": "^4.19.4"
   }
 }

--- a/packages/luxon-ext/package.json
+++ b/packages/luxon-ext/package.json
@@ -30,8 +30,8 @@
   "types": "dist/index.d.ts",
   "files": ["dist", "package.json"],
   "devDependencies": {
-    "@types/luxon": "^3.4.2",
-    "luxon": "^3.5.0"
+    "@types/luxon": "^3.6.2",
+    "luxon": "^3.6.1"
   },
   "peerDependencies": {
     "luxon": "^3"

--- a/packages/try-automerge/package.json
+++ b/packages/try-automerge/package.json
@@ -31,6 +31,6 @@
   "types": "dist/index.d.ts",
   "files": ["dist", "package.json"],
   "dependencies": {
-    "@automerge/automerge": "^2.2.8"
+    "@automerge/automerge": "^2.2.9"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,22 +12,22 @@ importers:
         specifier: ^1.9.4
         version: 1.9.4
       '@swc/core':
-        specifier: ^1.10.18
+        specifier: ^1.11.24
         version: 1.11.24
       '@vitest/coverage-v8':
         specifier: 3.1.3
         version: 3.1.3(vitest@3.1.3(tsx@4.19.4)(yaml@2.8.0))
       tsup:
-        specifier: ^8.3.6
+        specifier: ^8.5.0
         version: 8.5.0(@swc/core@1.11.24)(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.0)
       typedoc:
-        specifier: ^0.28.0
+        specifier: ^0.28.4
         version: 0.28.4(typescript@5.8.3)
       typescript:
-        specifier: ^5.7.3
+        specifier: ^5.8.3
         version: 5.8.3
       vitest:
-        specifier: ^3.0.6
+        specifier: ^3.1.3
         version: 3.1.3(tsx@4.19.4)(yaml@2.8.0)
 
   packages/hello: {}
@@ -35,7 +35,7 @@ importers:
   packages/incremental-color-palette:
     devDependencies:
       tsx:
-        specifier: ^4.19.3
+        specifier: ^4.19.4
         version: 4.19.4
 
   packages/intended-rollback: {}
@@ -43,10 +43,10 @@ importers:
   packages/luxon-ext:
     devDependencies:
       '@types/luxon':
-        specifier: ^3.4.2
+        specifier: ^3.6.2
         version: 3.6.2
       luxon:
-        specifier: ^3.5.0
+        specifier: ^3.6.1
         version: 3.6.1
 
   packages/mymath: {}
@@ -58,7 +58,7 @@ importers:
   packages/try-automerge:
     dependencies:
       '@automerge/automerge':
-        specifier: ^2.2.8
+        specifier: ^2.2.9
         version: 2.2.9
 
   packages/word-stats: {}


### PR DESCRIPTION
- Exclude EoL v18
- Add support for released v24
- Update other versions
