### PR TITLE
Perform type checking using tsc --noEmit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,8 +35,10 @@ jobs:
           pnpm install
 
       - name: Lint
-        run: |
-          pnpm lint
+        run: pnpm lint
+
+      - name: Typecheck
+        run: pnpm typecheck
 
       - name: Build
         run: pnpm build

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "format": "biome check --write ./",
     "lint": "biome check ./",
     "test": "vitest run --coverage",
+    "typecheck": "tsc --noEmit packages/*/**/*.ts --skipLibCheck --downlevelIteration",
     "typedoc": "pnpm build && typedoc",
     "typedoc:server": "python3 -m http.server --directory build/typedocs"
   },

--- a/packages/hello/src/index.test.ts
+++ b/packages/hello/src/index.test.ts
@@ -14,7 +14,7 @@ describe('printHello', () => {
   })
 
   it('prints "Hello, world!"', () => {
-    const spy = vi.spyOn(console, 'log').mockImplementation()
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {})
     printHello()
     expect(spy).toHaveBeenCalledWith('Hello, world!')
     spy.mockRestore()

--- a/packages/incremental-color-palette/examples/example.ts
+++ b/packages/incremental-color-palette/examples/example.ts
@@ -1,4 +1,4 @@
-import fs from 'node:fs'
+import { writeFileSync } from 'node:fs'
 import { type WaveParameter, uintToRGB } from '../src/'
 
 const main = () => {
@@ -17,7 +17,7 @@ const main = () => {
   )
   const html = colorsToHtml(colors)
 
-  fs.writeFileSync('example.html', html)
+  writeFileSync('example.html', html)
 }
 
 const colorsToHtml = (colors: [number, number, number][]) => {

--- a/packages/incremental-color-palette/package.json
+++ b/packages/incremental-color-palette/package.json
@@ -31,6 +31,7 @@
   "types": "dist/index.d.ts",
   "files": ["dist", "package.json"],
   "devDependencies": {
+    "@types/node": "^22.15.30",
     "tsx": "^4.19.4"
   }
 }

--- a/packages/object-version-control/package.json
+++ b/packages/object-version-control/package.json
@@ -32,6 +32,7 @@
   "types": "dist/index.d.ts",
   "files": ["dist", "package.json"],
   "dependencies": {
+    "jsondiffpatch": "^0.7.0",
     "js-sha256": "^0.11.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,9 @@ importers:
 
   packages/incremental-color-palette:
     devDependencies:
+      '@types/node':
+        specifier: ^22.15.30
+        version: 22.15.30
       tsx:
         specifier: ^4.19.4
         version: 4.19.4
@@ -56,6 +59,9 @@ importers:
       js-sha256:
         specifier: ^0.11.0
         version: 0.11.1
+      jsondiffpatch:
+        specifier: ^0.7.0
+        version: 0.7.3
     devDependencies:
       '@automerge/automerge':
         specifier: ^2.2.8
@@ -63,9 +69,6 @@ importers:
       '@types/node':
         specifier: ^22.13.4
         version: 22.15.30
-      jsondiffpatch:
-        specifier: ^0.7.0
-        version: 0.7.3
 
   packages/string: {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
   "exclude": [
     "**/*.test.ts",
     "**/*.spec.ts",
+    "**/dist/**/*",
     "node_modules",
     "**/examples/**/*"
   ]


### PR DESCRIPTION
- I had a misunderstanding. I thought that if I used biome.js, it would automatically perform type checking.
- Type checking needs to be performed separately.
- For that purpose, I will use tsc --noEmit.
