### PR TITLE
Set "sideEffects": false for tree-shaking optimization

### DIFF
--- a/packages/cipher/package.json
+++ b/packages/cipher/package.json
@@ -25,6 +25,7 @@
       }
     }
   },
+  "sideEffects": false,
   "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/incremental-color-palette/package.json
+++ b/packages/incremental-color-palette/package.json
@@ -26,6 +26,7 @@
       }
     }
   },
+  "sideEffects": false,
   "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/intended-rollback/package.json
+++ b/packages/intended-rollback/package.json
@@ -25,6 +25,7 @@
       }
     }
   },
+  "sideEffects": false,
   "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mymath/package.json
+++ b/packages/mymath/package.json
@@ -25,6 +25,7 @@
       }
     }
   },
+  "sideEffects": false,
   "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/word-stats/package.json
+++ b/packages/word-stats/package.json
@@ -25,6 +25,7 @@
       }
     }
   },
+  "sideEffects": false,
   "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
- Set "sideEffects": false in package.json files of the following packages:
  - cipher
  - incremental-color-palette
  - intended-rollback
  - mymath
  - word-stats
These packages are functional and do not have side effects.
So they can be tree-shaken by bundlers like Webpack, Rollup, esbuild, etc.
`"sideEffects": false` tells the bundler that these packages do not have side effects,
