### PR TITLE
chore: approve-builds @swc/core

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,5 @@
 packages:
-  - 'packages/*'
+  - packages/*
+
+onlyBuiltDependencies:
+  - '@swc/core'


### PR DESCRIPTION
- @swc/core uses postinstall script to build the package
- This PR approves the builds for @swc/core
