### PR TITLE
Stop build with `--parallel` option

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "description": "A playground for TypeScript",
   "workspaces": ["packages/*"],
   "scripts": {
-    "build": "pnpm -r --parallel build",
+    "build": "pnpm -r build",
     "dev": "pnpm --parallel dev",
     "format": "biome check --write ./",
     "lint": "biome check ./",


### PR DESCRIPTION
- https://pnpm.io/cli/run#--parallel
> Completely disregard concurrency and topological sorting, running a given script immediately in all matching packages with prefixed streaming output. This is the preferred flag for long-running processes over many packages, for instance, a lengthy build process.

With `--parallel` option may make the builds slower.
This option is not useful for `pnpm build` case but useful for `pnpm dev` case.
In my local environment, it takes 30 seconds in parallel mode and 25 seconds in non-parallel mode.
