### PR TITLE
Implement: number-time

### DIFF
--- a/packages/number-time/package.json
+++ b/packages/number-time/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@kitsuyui/number-time",
+  "type": "module",
+  "version": "0.0.0",
+  "license": "MIT",
+  "author": "Yui Kitsu <kitsuyui@kitsuyui.com>",
+  "description": "Treat number as time",
+  "scripts": {
+    "build": "tsup --clean",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "validate": "validate-package-exports --check --verify"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kitsuyui/ts-playground.git"
+  },
+  "exports": {
+    ".": {
+      "require": {
+        "type": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      },
+      "import": {
+        "type": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    },
+    "./toText": {
+      "require": {
+        "type": "./dist/toText.d.cts",
+        "default": "./dist/toText.cjs"
+      },
+      "import": {
+        "type": "./dist/toText.d.ts",
+        "default": "./dist/toText.js"
+      }
+    }
+  },
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist", "package.json"],
+  "devDependencies": {}
+}

--- a/packages/number-time/src/index.spec.ts
+++ b/packages/number-time/src/index.spec.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+import * as module from './index'
+
+describe('module', () => {
+  it('should export all functions', () => {
+    expect(module).toHaveProperty('toText')
+    expect(module.toText).toHaveProperty('zeroPad')
+    expect(module.toText).toHaveProperty('zeroPad2')
+    expect(module.toText).toHaveProperty('zeroPad3')
+    expect(module.toText).toHaveProperty('toText')
+  })
+})

--- a/packages/number-time/src/index.ts
+++ b/packages/number-time/src/index.ts
@@ -1,0 +1,1 @@
+export * as toText from './toText'

--- a/packages/number-time/src/toText.spec.ts
+++ b/packages/number-time/src/toText.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+
+import { toText, zeroPad, zeroPad2, zeroPad3 } from './toText'
+
+describe('zeroPadNumber', () => {
+  it('should zero pad a number to a given length', () => {
+    expect(zeroPad(1, 2)).toEqual('01')
+    expect(zeroPad(1, 3)).toEqual('001')
+    expect(zeroPad(1, 4)).toEqual('0001')
+    expect(zeroPad(10, 2)).toEqual('10')
+    expect(zeroPad(100, 3)).toEqual('100')
+    expect(zeroPad(1000, 4)).toEqual('1000')
+  })
+})
+
+describe('zeroPadNumber2', () => {
+  it('should zero pad a number to 2 digits', () => {
+    expect(zeroPad2(0)).toEqual('00')
+    expect(zeroPad2(1)).toEqual('01')
+    expect(zeroPad2(9)).toEqual('09')
+    expect(zeroPad2(10)).toEqual('10')
+  })
+})
+
+describe('zeroPadNumber3', () => {
+  it('should zero pad a number to 3 digits', () => {
+    expect(zeroPad3(1)).toEqual('001')
+    expect(zeroPad3(10)).toEqual('010')
+    expect(zeroPad3(100)).toEqual('100')
+  })
+})
+
+describe('toLabel', () => {
+  it('should format time value to mm:ss.mmm', () => {
+    expect(toText(0)).toBe('00:00.000')
+    expect(toText(1)).toBe('00:01.000')
+    expect(toText(59)).toBe('00:59.000')
+    expect(toText(60)).toBe('01:00.000')
+    expect(toText(61)).toBe('01:01.000')
+    expect(toText(3599)).toBe('59:59.000')
+  })
+})

--- a/packages/number-time/src/toText.ts
+++ b/packages/number-time/src/toText.ts
@@ -1,0 +1,50 @@
+/**
+ * Pad a number with zeros to a given length
+ * @param num {number}
+ * @param length {number}
+ * @returns zero padded number
+ * @example
+ * zeroPad(1, 2) // '01'
+ * zeroPad(1, 3) // '001'
+ */
+export const zeroPad = (num: number, length: number): string => {
+  return String(num).padStart(length, '0')
+}
+
+/**
+ * Pad a number with zeros to a length of 2
+ * @param num {number}
+ * @returns {string} zero padded number
+ * @example
+ * zeroPad2(1) // '01'
+ * zeroPad2(10) // '10'
+ */
+export const zeroPad2 = (num: number): string => {
+  return zeroPad(num, 2)
+}
+
+/**
+ * Pad a number with zeros to a length of 3
+ * @param num {number}
+ * @returns zero padded number
+ * @example
+ * zeroPad3(1) // '001'
+ * zeroPad3(10) // '010'
+ * zeroPad3(100) // '100'
+ */
+export const zeroPad3 = (num: number): string => {
+  return zeroPad(num, 3)
+}
+
+/**
+ * Convert a time value in seconds to a label string
+ * The format is `mm:ss.mmm` where:
+ * @param value
+ * @returns formatted time label
+ */
+export const toText = (value: number): string => {
+  const minutes = Math.floor(value / 60)
+  const seconds = (value % 60) | 0
+  const milliseconds = ((value % 1) * 1000) | 0
+  return `${zeroPad2(minutes)}:${zeroPad2(seconds)}.${zeroPad3(milliseconds)}`
+}


### PR DESCRIPTION
- This module provides utility functions to format numbers as text, specifically for time values.
- This module is spinning off from `@kitsuyui/react-playground` (clock, timer, stopwatch) packages.
