### PR TITLE
Fix: check-module-isolation subcommand exit code

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dev": "pnpm --parallel dev",
     "format": "biome check --write ./",
     "lint": "biome check ./",
-    "check-module-isolation": "find packages -type d -name src -print -exec pnpm ts-module-isolation -- {} \\;",
+    "check-module-isolation": "find packages -type d -name src -print -exec pnpm ts-module-isolation -- {} +",
     "test": "vitest run --coverage",
     "validate": "pnpm -r validate",
     "typecheck": "tsc --noEmit packages/*/**/*.ts --skipLibCheck --downlevelIteration",


### PR DESCRIPTION
- Use `-exec ... {} +` in find command
  - Using `-exec ... {} \;` in the `find` command causes the exit code to be 0 even if an error occurs.
