### PR TITLE
ci: switch Renovate to self-hosted GitHub Actions

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -23,3 +23,6 @@ jobs:
         uses: renovatebot/github-action@v46.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          RENOVATE_PLATFORM: github
+          RENOVATE_REPOSITORIES: ${{ github.repository }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -2,6 +2,9 @@ name: renovate
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - chore/setup-renovate-github-action
   schedule:
     - cron: '0 3 * * *'
 
@@ -19,4 +22,4 @@ jobs:
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@v46.1.1
         with:
-          token: ${{ secrets.RENOVATE_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,22 @@
+name: renovate
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 3 * * *'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@v46.1.1
+        with:
+          token: ${{ secrets.RENOVATE_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Playground for TypeScript
 ## Dependency updates
 
 - Renovate execution is switched to a self-hosted GitHub Action in `.github/workflows/renovate.yml`.
-- Set repository secret `RENOVATE_TOKEN` before enabling it.
-- Use a classic Personal Access Token with at least `repo` and `workflow` scopes.
+- For this branch experiment, the workflow uses `GITHUB_TOKEN`.
+- For stable operation, use `RENOVATE_TOKEN` (classic PAT with at least `repo` and `workflow` scopes).
 - Disable previous Renovate App/SaaS execution to avoid duplicate pull requests during migration.
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ Playground for TypeScript
 
 - TypeDoc: https://ts-playground.typedoc.kitsuyui.com/
 
+## Dependency updates
+
+- Renovate execution is switched to a self-hosted GitHub Action in `.github/workflows/renovate.yml`.
+- Set repository secret `RENOVATE_TOKEN` before enabling it.
+- Use a classic Personal Access Token with at least `repo` and `workflow` scopes.
+- Disable previous Renovate App/SaaS execution to avoid duplicate pull requests during migration.
+
 ## Usage
 
 ### Install


### PR DESCRIPTION
## Summary
- switch Renovate execution to self-hosted GitHub Actions
- keep scheduled and workflow_dispatch runs for dependency updates
- document required RENOVATE_TOKEN secret in README

## Details
- workflow file: .github/workflows/renovate.yml
- disable previous Renovate App/SaaS execution to avoid duplicate PRs during migration
- required secret: RENOVATE_TOKEN (classic PAT with repo and workflow scopes)

## Why
- centralize Renovate execution in this repository GitHub Actions
- keep dependency update automation predictable and visible
