### PR TITLE
WIP: extract biticon core and inline internal packages

### DIFF
--- a/packages/biticon-core/README.md
+++ b/packages/biticon-core/README.md
@@ -1,0 +1,3 @@
+# @kitsuyui/biticon-core
+
+Core utilities for generating bit-based icon data.

--- a/packages/biticon-core/package.json
+++ b/packages/biticon-core/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@kitsuyui/biticon-core",
+  "type": "module",
+  "version": "0.0.0",
+  "license": "MIT",
+  "author": "Yui Kitsu <kitsuyui@kitsuyui.com>",
+  "description": "Core utilities for bit-based icons",
+  "scripts": {
+    "build": "tsdown",
+    "dev": "tsdown --no-clean --watch",
+    "test": "vitest run",
+    "validate": "validate-package-exports --check"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kitsuyui/ts-playground.git"
+  },
+  "exports": {
+    ".": {
+      "require": {
+        "type": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      },
+      "import": {
+        "type": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "sideEffects": false,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "package.json"
+  ],
+  "devDependencies": {
+    "@kitsuyui/cipher": "workspace:*"
+  }
+}

--- a/packages/biticon-core/src/bitShuffle.spec.ts
+++ b/packages/biticon-core/src/bitShuffle.spec.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+
+import { applySBox128bitBigintTo128bitBigint } from './bitShuffle'
+
+describe('applySBox128bitBigintTo128bitBigint', () => {
+  it('applies the S-Box pipeline to a 128-bit bigint', () => {
+    const input = BigInt('0x0123456789abcdef0123456789abcdef')
+
+    expect(applySBox128bitBigintTo128bitBigint(input)).toBe(
+      104690180703241483303067873224999727776n
+    )
+  })
+
+  it('handles zero input', () => {
+    expect(applySBox128bitBigintTo128bitBigint(0n)).toBe(
+      284235859428078010657642319148888741333n
+    )
+  })
+})

--- a/packages/biticon-core/src/bitShuffle.ts
+++ b/packages/biticon-core/src/bitShuffle.ts
@@ -1,0 +1,21 @@
+import {
+  RijndaelSBox,
+  utils,
+  xorShuffle as xorShuffleModule,
+} from '@kitsuyui/cipher'
+
+const applyMultipleTimes = (input: Uint8Array, times: number): Uint8Array => {
+  let output = input
+  for (let i = 0; i < times; i++) {
+    output = xorShuffleModule.xorShuffle(output)
+    output = RijndaelSBox.applySBox(output)
+    output = xorShuffleModule.xorShuffle(output)
+  }
+  return output
+}
+
+export const applySBox128bitBigintTo128bitBigint = (input: bigint): bigint => {
+  const inputArray = utils.bigint128bitToUint8Array(input)
+  const outputArray = applyMultipleTimes(inputArray, 16)
+  return utils.uint8ArrayToBigint128bit(outputArray)
+}

--- a/packages/biticon-core/src/bits.spec.ts
+++ b/packages/biticon-core/src/bits.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+
+import { from2bitArrayTo128bit, from128bitTo2bitArray, is128Bit } from './bits'
+
+describe('from128bitTo2bitArray', () => {
+  it('converts a 128-bit bigint to a 64-item Uint8Array', () => {
+    const input = BigInt('0xfedcba9876543210fedcba9876543210')
+    expect(is128Bit(input)).toBe(true)
+
+    const output = from128bitTo2bitArray(input)
+
+    expect(output).toHaveLength(64)
+    for (const value of output) {
+      expect(value).toBeGreaterThanOrEqual(0)
+      expect(value).toBeLessThanOrEqual(3)
+    }
+  })
+
+  it('round-trips with from2bitArrayTo128bit', () => {
+    const input = BigInt('0xfedcba9876543210fedcba9876543210')
+
+    expect(from2bitArrayTo128bit(from128bitTo2bitArray(input))).toBe(input)
+  })
+})
+
+describe('is128Bit', () => {
+  it('returns true only for non-negative 128-bit values', () => {
+    const input = BigInt('0xffffffffffffffffffffffffffffffff')
+
+    expect(is128Bit(input)).toBe(true)
+    expect(is128Bit(input + BigInt(1))).toBe(false)
+    expect(is128Bit(BigInt(-1))).toBe(false)
+  })
+})

--- a/packages/biticon-core/src/bits.ts
+++ b/packages/biticon-core/src/bits.ts
@@ -1,0 +1,37 @@
+export const is128Bit = (value: bigint): boolean => {
+  return (
+    value >= BigInt(0) && value <= BigInt('0xffffffffffffffffffffffffffffffff')
+  )
+}
+
+/**
+ * Convert 128-bit value to an array of 64 two-bit values.
+ */
+export const from128bitTo2bitArray = (value: bigint): Uint8Array => {
+  const mask = BigInt(0b11)
+  const bytes = new Uint8Array(64)
+  for (let i = 0; i < 64; i++) {
+    const bit = BigInt(i) * BigInt(2)
+    const valueAtBit = (value >> bit) & mask
+    bytes[i] = Number(valueAtBit)
+  }
+  return bytes
+}
+
+/**
+ * Convert an array of 64 two-bit values back to a 128-bit bigint.
+ */
+export const from2bitArrayTo128bit = (array: Uint8Array): bigint => {
+  if (array.length !== 64) {
+    throw new Error('Array length must be 64')
+  }
+  let value = BigInt(0)
+  for (let i = 0; i < array.length; i++) {
+    const bit = array[i]
+    if (bit > 3) {
+      throw new Error(`Invalid bit value: ${bit}`)
+    }
+    value |= BigInt(bit) << BigInt(i * 2)
+  }
+  return value
+}

--- a/packages/biticon-core/src/colors.ts
+++ b/packages/biticon-core/src/colors.ts
@@ -1,0 +1,9 @@
+// Based on the viridis colormap from the colormap package (CC0).
+export const COLORS = ['#440154', '#30678d', '#35b778', '#fde724'] as const
+
+/**
+ * Convert a two-bit value to a display color.
+ */
+export const valueToColor = (value: number): string => {
+  return COLORS[value]
+}

--- a/packages/biticon-core/src/index.spec.ts
+++ b/packages/biticon-core/src/index.spec.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest'
+
+import { COLORS, is128Bit, isValidUUID } from './index'
+
+describe('index', () => {
+  it('re-exports the public API', () => {
+    expect(COLORS).toHaveLength(4)
+    expect(is128Bit(0n)).toBe(true)
+    expect(isValidUUID('123e4567-e89b-12d3-a456-426614174000')).toBe(true)
+  })
+})

--- a/packages/biticon-core/src/index.ts
+++ b/packages/biticon-core/src/index.ts
@@ -1,0 +1,4 @@
+export * from './bitShuffle'
+export * from './bits'
+export * from './colors'
+export * from './uuid'

--- a/packages/biticon-core/src/uuid.spec.ts
+++ b/packages/biticon-core/src/uuid.spec.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+
+import { isValidUUID, uuidToBigInt } from './uuid'
+
+describe('isValidUUID', () => {
+  it('accepts valid UUIDs', () => {
+    expect(isValidUUID('123e4567-e89b-12d3-a456-426614174000')).toBe(true)
+    expect(isValidUUID('550e8400-e29b-41d4-a716-446655440000')).toBe(true)
+  })
+
+  it('rejects invalid UUIDs', () => {
+    expect(isValidUUID('123e4567-e89b-12d3-a456-42661417400')).toBe(false)
+    expect(isValidUUID('123e4567-e89b-12d3-a456-42661417400g')).toBe(false)
+  })
+})
+
+describe('uuidToBigInt', () => {
+  it('converts UUID text to a bigint', () => {
+    expect(uuidToBigInt('00000000-0000-0000-0000-000000000001')).toBe(1n)
+  })
+})

--- a/packages/biticon-core/src/uuid.ts
+++ b/packages/biticon-core/src/uuid.ts
@@ -1,0 +1,9 @@
+export const isValidUUID = (uuid: string): boolean => {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+    uuid
+  )
+}
+
+export const uuidToBigInt = (uuid: string): bigint => {
+  return BigInt(`0x${uuid.replace(/-/g, '')}`)
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,12 @@ importers:
         specifier: ^4.0.4
         version: 4.0.18(@types/node@24.10.13)(tsx@4.21.0)(yaml@2.8.2)
 
+  packages/biticon-core:
+    devDependencies:
+      '@kitsuyui/cipher':
+        specifier: workspace:*
+        version: link:../cipher
+
   packages/cipher: {}
 
   packages/debug: {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,10 @@
     "noFallthroughCasesInSwitch": true,
     "module": "esnext",
     "moduleResolution": "bundler",
+    "baseUrl": ".",
+    "paths": {
+      "@kitsuyui/*": ["packages/*/src/index.ts"]
+    },
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true

--- a/tsdown.config.mjs
+++ b/tsdown.config.mjs
@@ -10,4 +10,5 @@ export default defineConfig({
   sourcemap: true,
   minify: true,
   dts: true,
+  noExternal: [/^@kitsuyui\//],
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,17 @@
+import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
+  resolve: {
+    alias: [
+      {
+        find: /^@kitsuyui\/([^/]+)$/,
+        replacement: fileURLToPath(
+          new URL('./packages/$1/src/index.ts', import.meta.url)
+        ),
+      },
+    ],
+  },
   test: {
     /**
      * globals: true allows you to use describe, test, etc. without importing them


### PR DESCRIPTION
## Summary
- add a new @kitsuyui/biticon-core package for the non-React biticon logic moved out of react-playground
- configure tsdown to inline @kitsuyui/* package imports
- add workspace alias resolution for internal package imports during typecheck and tests

## Verification
- COREPACK_INTEGRITY_KEYS=0 pnpm --filter @kitsuyui/biticon-core test
- COREPACK_INTEGRITY_KEYS=0 pnpm --filter @kitsuyui/biticon-core build
- COREPACK_INTEGRITY_KEYS=0 pnpm --filter @kitsuyui/biticon-core validate
- COREPACK_INTEGRITY_KEYS=0 pnpm typecheck
- COREPACK_INTEGRITY_KEYS=0 pnpm lint
