### PR TITLE
Tighten Biome cognitive complexity checks

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -9,7 +9,7 @@
         "noExcessiveCognitiveComplexity": {
           "level": "error",
           "options": {
-            "maxAllowedComplexity": 5
+            "maxAllowedComplexity": 4
           }
         }
       },

--- a/biome.json
+++ b/biome.json
@@ -9,7 +9,7 @@
         "noExcessiveCognitiveComplexity": {
           "level": "error",
           "options": {
-            "maxAllowedComplexity": 11
+            "maxAllowedComplexity": 6
           }
         }
       },

--- a/biome.json
+++ b/biome.json
@@ -9,7 +9,7 @@
         "noExcessiveCognitiveComplexity": {
           "level": "error",
           "options": {
-            "maxAllowedComplexity": 4
+            "maxAllowedComplexity": 3
           }
         }
       },

--- a/biome.json
+++ b/biome.json
@@ -9,7 +9,7 @@
         "noExcessiveCognitiveComplexity": {
           "level": "error",
           "options": {
-            "maxAllowedComplexity": 14
+            "maxAllowedComplexity": 13
           }
         }
       },

--- a/biome.json
+++ b/biome.json
@@ -5,6 +5,14 @@
     "enabled": true,
     "rules": {
       "recommended": true,
+      "complexity": {
+        "noExcessiveCognitiveComplexity": {
+          "level": "error",
+          "options": {
+            "maxAllowedComplexity": 14
+          }
+        }
+      },
       "style": {
         "useImportType": "error",
         "noParameterAssign": "error",

--- a/biome.json
+++ b/biome.json
@@ -9,7 +9,7 @@
         "noExcessiveCognitiveComplexity": {
           "level": "error",
           "options": {
-            "maxAllowedComplexity": 13
+            "maxAllowedComplexity": 11
           }
         }
       },

--- a/biome.json
+++ b/biome.json
@@ -9,7 +9,7 @@
         "noExcessiveCognitiveComplexity": {
           "level": "error",
           "options": {
-            "maxAllowedComplexity": 6
+            "maxAllowedComplexity": 5
           }
         }
       },

--- a/packages/bits128/src/bits.ts
+++ b/packages/bits128/src/bits.ts
@@ -18,9 +18,6 @@ export const from128bitTo2bitArray = (value: bigint): Uint8Array => {
   return bytes
 }
 
-/**
- * Convert an array of 64 two-bit values back to a 128-bit bigint.
- */
 const to2bitBigInt = (bit: number): bigint => {
   if (bit > 3) {
     throw new Error(`Invalid bit value: ${bit}`)
@@ -28,6 +25,9 @@ const to2bitBigInt = (bit: number): bigint => {
   return BigInt(bit)
 }
 
+/**
+ * Convert an array of 64 two-bit values back to a 128-bit bigint.
+ */
 export const from2bitArrayTo128bit = (array: Uint8Array): bigint => {
   if (array.length !== 64) {
     throw new Error('Array length must be 64')

--- a/packages/bits128/src/bits.ts
+++ b/packages/bits128/src/bits.ts
@@ -21,17 +21,20 @@ export const from128bitTo2bitArray = (value: bigint): Uint8Array => {
 /**
  * Convert an array of 64 two-bit values back to a 128-bit bigint.
  */
+const to2bitBigInt = (bit: number): bigint => {
+  if (bit > 3) {
+    throw new Error(`Invalid bit value: ${bit}`)
+  }
+  return BigInt(bit)
+}
+
 export const from2bitArrayTo128bit = (array: Uint8Array): bigint => {
   if (array.length !== 64) {
     throw new Error('Array length must be 64')
   }
   let value = BigInt(0)
   for (let i = 0; i < array.length; i++) {
-    const bit = array[i]
-    if (bit > 3) {
-      throw new Error(`Invalid bit value: ${bit}`)
-    }
-    value |= BigInt(bit) << BigInt(i * 2)
+    value |= to2bitBigInt(array[i]) << BigInt(i * 2)
   }
   return value
 }

--- a/packages/cipher/src/xorShuffle.spec.ts
+++ b/packages/cipher/src/xorShuffle.spec.ts
@@ -2,6 +2,18 @@ import { describe, expect, it } from 'vitest'
 
 import { xorShuffle } from './xorShuffle'
 
+const repeatShuffle = (input: Uint8Array, iterations: number): Uint8Array => {
+  let output: Uint8Array = input
+  for (let i = 0; i < iterations; i++) {
+    output = xorShuffle(output)
+  }
+  return output
+}
+
+const createRandomInput = (size: number): Uint8Array => {
+  return new Uint8Array(size).map(() => Math.floor(Math.random() * 256))
+}
+
 describe('XOR Shuffle Operation', () => {
   const input = new Uint8Array([0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07])
 
@@ -13,11 +25,8 @@ describe('XOR Shuffle Operation', () => {
   })
 
   it('is idempotent after multiple iterations', () => {
-    let output: Uint8Array = input
     const iterations = input.length
-    for (let i = 0; i < iterations; i++) {
-      output = xorShuffle(output)
-    }
+    const output = repeatShuffle(input, iterations)
     expect(output.length).toBe(input.length)
     expect(output).toEqual(input)
   })
@@ -28,14 +37,8 @@ describe('XOR Shuffle Operation', () => {
     const sizes = [1, 2, 4, 8, 16, 32, 64, 128, 256]
     for (let i = 0; i < trials; i++) {
       const size = sizes[Math.floor(Math.random() * sizes.length)]
-      const iterations = size
-      const randomInput = new Uint8Array(size).map(() =>
-        Math.floor(Math.random() * 256)
-      )
-      let output: Uint8Array = randomInput
-      for (let j = 0; j < iterations; j++) {
-        output = xorShuffle(output)
-      }
+      const randomInput = createRandomInput(size)
+      const output = repeatShuffle(randomInput, size)
       expect(output.length).toBe(size)
       expect(output).toEqual(randomInput)
     }

--- a/packages/intended-rollback/src/base.ts
+++ b/packages/intended-rollback/src/base.ts
@@ -23,6 +23,42 @@ export const wrapWithRollback = <TClient, TClientTran, TContent>(
   return wrapped
 }
 
+const createSuccessResult = <TContent>(
+  content: TContent
+): Result<TContent> => ({
+  success: true,
+  content,
+  rollback: {
+    occurred: false,
+    intended: false,
+  },
+})
+
+const createIntendedRollbackResult = <TContent>(
+  content: TContent | null
+): Result<TContent> => {
+  if (content === null) {
+    throw new Unreachable('Intended rollback without content.')
+  }
+  return {
+    success: true,
+    content,
+    rollback: {
+      occurred: true,
+      intended: true,
+    },
+  }
+}
+
+const createFailureResult = <TContent>(error: unknown): Result<TContent> => ({
+  success: false,
+  error,
+  rollback: {
+    occurred: true,
+    intended: false,
+  },
+})
+
 /**
  * Handle rollback
  * @param client Client instance (i.e. database client like PrismaClient)
@@ -48,35 +84,11 @@ const handleRollback = async <TClient, TClientTran, TContent>(
       }
       return content_
     })
-    return {
-      success: true,
-      content,
-      rollback: {
-        occurred: false,
-        intended: false,
-      },
-    }
+    return createSuccessResult(content)
   } catch (e) {
     if (e instanceof IntendedRollback) {
-      if (content !== null) {
-        return {
-          success: true,
-          content,
-          rollback: {
-            occurred: true,
-            intended: true,
-          },
-        }
-      }
-      throw new Unreachable('Intended rollback without content.')
+      return createIntendedRollbackResult(content)
     }
-    return {
-      success: false,
-      error: e,
-      rollback: {
-        occurred: true,
-        intended: false,
-      },
-    }
+    return createFailureResult(e)
   }
 }

--- a/packages/is-local/src/index.ts
+++ b/packages/is-local/src/index.ts
@@ -12,11 +12,9 @@
  * @returns true if the host is local, false otherwise
  */
 export const isLocal = (host: string): boolean => {
-  if (isLocalhost(host)) return true
-  if (isIPv4Local(host)) return true
-  if (isIPv6Local(host)) return true
-  if (isLocalRFC6761(host)) return true
-  return false
+  return [isLocalhost, isIPv4Local, isIPv6Local, isLocalRFC6761].some((check) =>
+    check(host)
+  )
 }
 
 /**

--- a/packages/luxon-ext/src/rounding/index.spec.ts
+++ b/packages/luxon-ext/src/rounding/index.spec.ts
@@ -130,5 +130,12 @@ describe('roundDuration', () => {
         roundingMethod: 'floor',
       }).toObject()
     ).toEqual({ seconds: 0 })
+    expect(
+      roundDuration(Duration.fromObject({ years: 1, months: 7 }), {
+        numOfUnits: 1,
+        minUnit: 'months',
+        roundingMethod: 'floor',
+      }).toObject()
+    ).toEqual({ years: 1 })
   })
 })

--- a/packages/luxon-ext/src/rounding/index.ts
+++ b/packages/luxon-ext/src/rounding/index.ts
@@ -65,6 +65,31 @@ const shouldCarryRoundedUnit = (
   return false
 }
 
+const applyCarryRoundedUnit = (
+  rounded: DurationObjectUnits,
+  roundingMethod: RoundingMethod,
+  remainMillis: number,
+  roundingHigherUnit: TimeUnit | undefined,
+  roundingLowerUnit: TimeUnit | undefined
+): void => {
+  if (!roundingHigherUnit || !roundingLowerUnit) return
+  if (
+    !shouldCarryRoundedUnit(roundingMethod, remainMillis, roundingHigherUnit)
+  ) {
+    return
+  }
+  rounded[roundingHigherUnit] = (rounded[roundingHigherUnit] ?? 0) + 1
+}
+
+const ensureRoundedMinUnit = (
+  rounded: DurationObjectUnits,
+  minUnit: TimeUnit
+): void => {
+  if (Object.keys(rounded).length === 0) {
+    rounded[minUnit] = 0
+  }
+}
+
 /**
  * Round the duration
  * @param duration duration must be clean
@@ -94,17 +119,14 @@ export const roundDuration = (
   const rounded = collectRoundedUnits(useUnits, remain)
 
   const remainMillis = Duration.fromObject(remain).toMillis()
-  if (roundingHigherUnit && roundingLowerUnit) {
-    if (
-      shouldCarryRoundedUnit(roundingMethod, remainMillis, roundingHigherUnit)
-    ) {
-      rounded[roundingHigherUnit] = (rounded[roundingHigherUnit] ?? 0) + 1
-    }
-  }
-
-  if (Object.keys(rounded).length === 0) {
-    rounded[minUnit] = 0
-  }
+  applyCarryRoundedUnit(
+    rounded,
+    roundingMethod,
+    remainMillis,
+    roundingHigherUnit,
+    roundingLowerUnit
+  )
+  ensureRoundedMinUnit(rounded, minUnit)
 
   return Duration.fromObject(rounded)
 }

--- a/packages/luxon-ext/src/rounding/index.ts
+++ b/packages/luxon-ext/src/rounding/index.ts
@@ -37,6 +37,34 @@ export const cleanDuration = (duration: Duration): Duration => {
   return Duration.fromMillis(abs)
 }
 
+const collectRoundedUnits = (
+  useUnits: TimeUnit[],
+  remain: DurationObjectUnits
+): DurationObjectUnits => {
+  const rounded: DurationObjectUnits = {}
+  for (const unit of useUnits.slice(0, -1)) {
+    const value = remain[unit] ?? 0
+    if (value === 0) continue
+    rounded[unit] = value
+    delete remain[unit]
+  }
+  return rounded
+}
+
+const shouldCarryRoundedUnit = (
+  roundingMethod: RoundingMethod,
+  remainMillis: number,
+  roundingHigherUnit: TimeUnit
+): boolean => {
+  if (roundingMethod === 'ceil') {
+    return remainMillis > 0
+  }
+  if (roundingMethod === 'round') {
+    return remainMillis >= HALF_OF_TIME_UNITS[roundingHigherUnit]
+  }
+  return false
+}
+
 /**
  * Round the duration
  * @param duration duration must be clean
@@ -54,7 +82,6 @@ export const roundDuration = (
     opts ?? {}
   )
   const base = duration.shiftToAll().toObject()
-  const rounded: DurationObjectUnits = {}
   const remain: DurationObjectUnits = { ...base }
   const topUnit = computeTopUnit(duration)
   const useUnits = computeUseUnits({
@@ -64,21 +91,13 @@ export const roundDuration = (
   })
   const roundingHigherUnit = useUnits[useUnits.length - 2]
   const roundingLowerUnit = useUnits[useUnits.length - 1]
-
-  for (const unit of useUnits.slice(0, -1)) {
-    const value = remain[unit] ?? 0
-    if (value === 0) continue
-    rounded[unit] = value
-    delete remain[unit]
-  }
+  const rounded = collectRoundedUnits(useUnits, remain)
 
   const remainMillis = Duration.fromObject(remain).toMillis()
   if (roundingHigherUnit && roundingLowerUnit) {
-    const shouldCarry =
-      (roundingMethod === 'ceil' && remainMillis > 0) ||
-      (roundingMethod === 'round' &&
-        remainMillis >= HALF_OF_TIME_UNITS[roundingHigherUnit])
-    if (shouldCarry) {
+    if (
+      shouldCarryRoundedUnit(roundingMethod, remainMillis, roundingHigherUnit)
+    ) {
       rounded[roundingHigherUnit] = (rounded[roundingHigherUnit] ?? 0) + 1
     }
   }

--- a/packages/luxon-ext/src/rounding/index.ts
+++ b/packages/luxon-ext/src/rounding/index.ts
@@ -39,16 +39,23 @@ export const cleanDuration = (duration: Duration): Duration => {
 
 const collectRoundedUnits = (
   useUnits: TimeUnit[],
+  base: DurationObjectUnits
+): {
+  rounded: DurationObjectUnits
   remain: DurationObjectUnits
-): DurationObjectUnits => {
-  const roundedEntries = useUnits
-    .slice(0, -1)
-    .map((unit) => [unit, remain[unit] ?? 0] as const)
-    .filter(([, value]) => value !== 0)
-  for (const [unit] of roundedEntries) {
-    delete remain[unit]
+} => {
+  const roundedUnits = new Set<TimeUnit>(useUnits.slice(0, -1))
+  const entries = Object.entries(base) as [TimeUnit, number][]
+  const isRoundedEntry = ([unit, value]: [TimeUnit, number]): boolean =>
+    roundedUnits.has(unit) && value !== 0
+  return {
+    rounded: Object.fromEntries(
+      entries.filter(isRoundedEntry)
+    ) as DurationObjectUnits,
+    remain: Object.fromEntries(
+      entries.filter((entry) => !isRoundedEntry(entry))
+    ) as DurationObjectUnits,
   }
-  return Object.fromEntries(roundedEntries) as DurationObjectUnits
 }
 
 const shouldCarryRoundedUnit = (
@@ -81,31 +88,31 @@ const resolveCarryUnit = (
     : null
 }
 
-const applyCarryRoundedUnit = (
+const withCarryRoundedUnit = (
   rounded: DurationObjectUnits,
   roundingMethod: RoundingMethod,
   remainMillis: number,
   roundingHigherUnit: TimeUnit | undefined,
   roundingLowerUnit: TimeUnit | undefined
-): void => {
+): DurationObjectUnits => {
   const carryUnit = resolveCarryUnit(
     roundingMethod,
     remainMillis,
     roundingHigherUnit,
     roundingLowerUnit
   )
-  if (!carryUnit) return
-  rounded[carryUnit] = (rounded[carryUnit] ?? 0) + 1
-}
-
-const ensureRoundedMinUnit = (
-  rounded: DurationObjectUnits,
-  minUnit: TimeUnit
-): void => {
-  if (Object.keys(rounded).length === 0) {
-    rounded[minUnit] = 0
+  if (!carryUnit) return rounded
+  return {
+    ...rounded,
+    [carryUnit]: (rounded[carryUnit] ?? 0) + 1,
   }
 }
+
+const withRoundedMinUnit = (
+  rounded: DurationObjectUnits,
+  minUnit: TimeUnit
+): DurationObjectUnits =>
+  Object.keys(rounded).length === 0 ? { [minUnit]: 0 } : rounded
 
 /**
  * Round the duration
@@ -124,7 +131,6 @@ export const roundDuration = (
     opts ?? {}
   )
   const base = duration.shiftToAll().toObject()
-  const remain: DurationObjectUnits = { ...base }
   const topUnit = computeTopUnit(duration)
   const useUnits = computeUseUnits({
     top: topUnit,
@@ -133,17 +139,16 @@ export const roundDuration = (
   })
   const roundingHigherUnit = useUnits[useUnits.length - 2]
   const roundingLowerUnit = useUnits[useUnits.length - 1]
-  const rounded = collectRoundedUnits(useUnits, remain)
+  const { rounded, remain } = collectRoundedUnits(useUnits, base)
 
   const remainMillis = Duration.fromObject(remain).toMillis()
-  applyCarryRoundedUnit(
+  const roundedWithCarry = withCarryRoundedUnit(
     rounded,
     roundingMethod,
     remainMillis,
     roundingHigherUnit,
     roundingLowerUnit
   )
-  ensureRoundedMinUnit(rounded, minUnit)
 
-  return Duration.fromObject(rounded)
+  return Duration.fromObject(withRoundedMinUnit(roundedWithCarry, minUnit))
 }

--- a/packages/luxon-ext/src/rounding/index.ts
+++ b/packages/luxon-ext/src/rounding/index.ts
@@ -41,14 +41,14 @@ const collectRoundedUnits = (
   useUnits: TimeUnit[],
   remain: DurationObjectUnits
 ): DurationObjectUnits => {
-  const rounded: DurationObjectUnits = {}
-  for (const unit of useUnits.slice(0, -1)) {
-    const value = remain[unit] ?? 0
-    if (value === 0) continue
-    rounded[unit] = value
+  const roundedEntries = useUnits
+    .slice(0, -1)
+    .map((unit) => [unit, remain[unit] ?? 0] as const)
+    .filter(([, value]) => value !== 0)
+  for (const [unit] of roundedEntries) {
     delete remain[unit]
   }
-  return rounded
+  return Object.fromEntries(roundedEntries) as DurationObjectUnits
 }
 
 const shouldCarryRoundedUnit = (
@@ -65,6 +65,22 @@ const shouldCarryRoundedUnit = (
   return false
 }
 
+const resolveCarryUnit = (
+  roundingMethod: RoundingMethod,
+  remainMillis: number,
+  roundingHigherUnit: TimeUnit | undefined,
+  roundingLowerUnit: TimeUnit | undefined
+): TimeUnit | null => {
+  if (!roundingHigherUnit || !roundingLowerUnit) return null
+  return shouldCarryRoundedUnit(
+    roundingMethod,
+    remainMillis,
+    roundingHigherUnit
+  )
+    ? roundingHigherUnit
+    : null
+}
+
 const applyCarryRoundedUnit = (
   rounded: DurationObjectUnits,
   roundingMethod: RoundingMethod,
@@ -72,13 +88,14 @@ const applyCarryRoundedUnit = (
   roundingHigherUnit: TimeUnit | undefined,
   roundingLowerUnit: TimeUnit | undefined
 ): void => {
-  if (!roundingHigherUnit || !roundingLowerUnit) return
-  if (
-    !shouldCarryRoundedUnit(roundingMethod, remainMillis, roundingHigherUnit)
-  ) {
-    return
-  }
-  rounded[roundingHigherUnit] = (rounded[roundingHigherUnit] ?? 0) + 1
+  const carryUnit = resolveCarryUnit(
+    roundingMethod,
+    remainMillis,
+    roundingHigherUnit,
+    roundingLowerUnit
+  )
+  if (!carryUnit) return
+  rounded[carryUnit] = (rounded[carryUnit] ?? 0) + 1
 }
 
 const ensureRoundedMinUnit = (

--- a/packages/mymath/src/array/index.spec.ts
+++ b/packages/mymath/src/array/index.spec.ts
@@ -124,4 +124,10 @@ describe('generalizedMean', () => {
       geometricMean(values)
     )
   })
+
+  it('should throw for empty arrays when p is less than 1 and not a special case', () => {
+    expect(() => generalizedMean([], 0.5)).toThrowError(
+      'Cannot calculate generalized mean of empty set'
+    )
+  })
 })

--- a/packages/mymath/src/array/index.ts
+++ b/packages/mymath/src/array/index.ts
@@ -138,6 +138,14 @@ export const cubicMean = (values: number[]): number => {
   return Math.cbrt(arithmeticMean(values.map((value) => value ** 3)))
 }
 
+const specialGeneralizedMean = (values: number[], p: number): number | null => {
+  if (p === Number.NEGATIVE_INFINITY) return Math.min(...values) // p -> -∞ means min
+  if (p === 0) return geometricMean(values)
+  if (p === 1) return arithmeticMean(values)
+  if (p === Number.POSITIVE_INFINITY) return Math.max(...values) // p -> +∞ means max
+  return null
+}
+
 /**
  * Aware implementation of generalized mean (Hölder mean) of all values in the array
  * @param values
@@ -145,13 +153,12 @@ export const cubicMean = (values: number[]): number => {
  * @returns
  */
 const awareGeneralizedMean = (values: number[], p: number): number => {
-  if (p === Number.NEGATIVE_INFINITY) return Math.min(...values) // p -> -∞ means min
-  if (p === 0) return geometricMean(values)
-  if (p === 1) return arithmeticMean(values)
-  if (p === Number.POSITIVE_INFINITY) return Math.max(...values) // p -> +∞ means max
-  const n = values.length
-  if (p > 1 && n === 0) return 0
-  if (n === 0) throw new Error('Cannot calculate generalized mean of empty set')
+  const specialMean = specialGeneralizedMean(values, p)
+  if (specialMean !== null) return specialMean
+  if (values.length === 0) {
+    if (p > 1) return 0
+    throw new Error('Cannot calculate generalized mean of empty set')
+  }
   return naiveGeneralizedMean(values, p)
 }
 

--- a/packages/mymath/src/array/index.ts
+++ b/packages/mymath/src/array/index.ts
@@ -138,12 +138,22 @@ export const cubicMean = (values: number[]): number => {
   return Math.cbrt(arithmeticMean(values.map((value) => value ** 3)))
 }
 
-const specialGeneralizedMean = (values: number[], p: number): number | null => {
-  if (p === Number.NEGATIVE_INFINITY) return Math.min(...values) // p -> -∞ means min
-  if (p === 0) return geometricMean(values)
-  if (p === 1) return arithmeticMean(values)
-  if (p === Number.POSITIVE_INFINITY) return Math.max(...values) // p -> +∞ means max
-  return null
+const specialGeneralizedMeanHandlers = new Map<
+  number,
+  (values: number[]) => number
+>([
+  [Number.NEGATIVE_INFINITY, (values) => Math.min(...values)],
+  [0, geometricMean],
+  [1, arithmeticMean],
+  [Number.POSITIVE_INFINITY, (values) => Math.max(...values)],
+])
+
+const specialGeneralizedMean = (values: number[], p: number): number | null =>
+  specialGeneralizedMeanHandlers.get(p)?.(values) ?? null
+
+const generalizedMeanOfEmptySet = (p: number): number => {
+  if (p > 1) return 0
+  throw new Error('Cannot calculate generalized mean of empty set')
 }
 
 /**
@@ -155,10 +165,7 @@ const specialGeneralizedMean = (values: number[], p: number): number | null => {
 const awareGeneralizedMean = (values: number[], p: number): number => {
   const specialMean = specialGeneralizedMean(values, p)
   if (specialMean !== null) return specialMean
-  if (values.length === 0) {
-    if (p > 1) return 0
-    throw new Error('Cannot calculate generalized mean of empty set')
-  }
+  if (values.length === 0) return generalizedMeanOfEmptySet(p)
   return naiveGeneralizedMean(values, p)
 }
 

--- a/packages/mymath/src/polar/index.spec.ts
+++ b/packages/mymath/src/polar/index.spec.ts
@@ -156,4 +156,18 @@ describe('kMeans', () => {
     expect(kMeans([], 2)).toEqual([[], []])
     expect(kMeans([0, 1], 0)).toEqual([[], []])
   })
+
+  it('should keep going when some clusters become empty', () => {
+    const [centers, labels] = kMeans([0], 2)
+
+    expect(centers).toEqual([0, 0])
+    expect(labels).toEqual([0])
+  })
+
+  it('should return the current centers when max iterations is zero', () => {
+    const [centers, labels] = kMeans([0, Math.PI], 2, 0)
+
+    expect(centers).toEqual([0, Math.PI])
+    expect(labels).toEqual([0, 1])
+  })
 })

--- a/packages/mymath/src/polar/index.ts
+++ b/packages/mymath/src/polar/index.ts
@@ -107,21 +107,21 @@ export const opposite = (rad: number): number => {
   return rotate(rad, Math.PI)
 }
 
-const assignLabels = (rads: number[], centers: number[]): number[] => {
-  const labels = new Array(rads.length).fill(-1)
-  for (let i = 0; i < rads.length; i++) {
-    let minDistance = Math.PI * 2
-    let minIndex = -1
-    for (let j = 0; j < centers.length; j++) {
-      const circularDistance = distance(rads[i], centers[j])
-      if (circularDistance < minDistance) {
-        minDistance = circularDistance
-        minIndex = j
-      }
+const findClosestCenterIndex = (rad: number, centers: number[]): number => {
+  let minDistance = Math.PI * 2
+  let minIndex = -1
+  for (let j = 0; j < centers.length; j++) {
+    const circularDistance = distance(rad, centers[j])
+    if (circularDistance < minDistance) {
+      minDistance = circularDistance
+      minIndex = j
     }
-    labels[i] = minIndex
   }
-  return labels
+  return minIndex
+}
+
+const assignLabels = (rads: number[], centers: number[]): number[] => {
+  return rads.map((rad) => findClosestCenterIndex(rad, centers))
 }
 
 /**

--- a/packages/mymath/src/polar/index.ts
+++ b/packages/mymath/src/polar/index.ts
@@ -10,10 +10,7 @@ import { sum } from '../array'
  * console.log(normalized); // Output: 3.141592653589793
  */
 export const toUnsignedRad = (rad: number): number => {
-  if (Number.isNaN(rad)) {
-    return Number.NaN
-  }
-  if (rad === Number.POSITIVE_INFINITY || rad === Number.NEGATIVE_INFINITY) {
+  if (!Number.isFinite(rad)) {
     return Number.NaN
   }
   let normalized = rad
@@ -124,6 +121,64 @@ const assignLabels = (rads: number[], centers: number[]): number[] => {
   return rads.map((rad) => findClosestCenterIndex(rad, centers))
 }
 
+const computeNextCenters = (
+  rads: number[],
+  labels: number[],
+  k: number
+): number[] => {
+  return new Array(k).fill(0).map((_, j) => {
+    const clusterItems = rads.filter((_, i) => labels[i] === j)
+    if (clusterItems.length === 0) {
+      return rads[j % rads.length]
+    }
+    return averageUnsigned(clusterItems)
+  })
+}
+
+const sortCentersAndRelabel = (
+  centers: number[],
+  labels: number[]
+): [number[], number[]] => {
+  const sorted = centers
+    .map((center, oldIndex) => ({ center, oldIndex }))
+    .sort((a, b) => a.center - b.center)
+  const remap = new Map<number, number>()
+  sorted.forEach((item, newIndex) => {
+    remap.set(item.oldIndex, newIndex)
+  })
+  return [
+    sorted.map((item) => item.center),
+    labels.map((label) => remap.get(label) ?? label),
+  ]
+}
+
+const iterateKMeans = (
+  rads: number[],
+  centers: number[],
+  labels: number[],
+  k: number,
+  maxIterations: number
+): [number[], number[]] => {
+  let currentCenters = centers
+  let currentLabels = labels
+  let iterations = 0
+  while (iterations < maxIterations) {
+    iterations++
+    currentLabels = assignLabels(rads, currentCenters)
+    const prevCenters = [...currentCenters]
+    ;[currentCenters, currentLabels] = sortCentersAndRelabel(
+      computeNextCenters(rads, currentLabels, k),
+      currentLabels
+    )
+    if (
+      currentCenters.every((center, index) => center === prevCenters[index])
+    ) {
+      return [currentCenters, currentLabels]
+    }
+  }
+  return [currentCenters, currentLabels]
+}
+
 /**
  * Runs k-means clustering on circular values.
  * @param rads
@@ -141,32 +196,7 @@ export const kMeans = (
   }
   let centers = new Array(k).fill(0).map((_, i) => (i * 2 * Math.PI) / k)
   let labels = new Array(rads.length).fill(-1)
-  let iterations = 0
-
-  while (iterations < maxIterations) {
-    iterations++
-    labels = assignLabels(rads, centers)
-    const prevCenters = [...centers]
-    const nextCenters = new Array(k).fill(0).map((_, j) => {
-      const clusterItems = rads.filter((_, i) => labels[i] === j)
-      if (clusterItems.length === 0) {
-        return rads[j % rads.length]
-      }
-      return averageUnsigned(clusterItems)
-    })
-    const sorted = nextCenters
-      .map((center, oldIndex) => ({ center, oldIndex }))
-      .sort((a, b) => a.center - b.center)
-    const remap = new Map<number, number>()
-    sorted.forEach((item, newIndex) => {
-      remap.set(item.oldIndex, newIndex)
-    })
-    centers = sorted.map((item) => item.center)
-    labels = labels.map((label) => remap.get(label) ?? label)
-    if (centers.every((center, index) => center === prevCenters[index])) {
-      break
-    }
-  }
+  ;[centers, labels] = iterateKMeans(rads, centers, labels, k, maxIterations)
 
   labels = assignLabels(rads, centers)
   return [centers, labels]

--- a/packages/object-version-control/src/core.spec.ts
+++ b/packages/object-version-control/src/core.spec.ts
@@ -65,4 +65,41 @@ describe('Core', () => {
     commit1.timestamp = 0
     expect(core.getSnapshotDataByCommitHash(commitHash)).toEqual(data)
   })
+
+  it('verifies valid repositories', () => {
+    const core = Core.create()
+    const baseHash = core.commit({ key: 'value' }, [])
+    core.commit({ key: 'next' }, [baseHash])
+
+    expect(core.verifyAll()).toBe(true)
+  })
+
+  it('detects invalid snapshots during repository verification', () => {
+    const core = Core.create()
+    const commitHash = core.commit({ key: 'value' }, [])
+    const commit = core.getCommit(commitHash)
+    const snapshots = (core as unknown as { snapshots: Map<string, unknown> })
+      .snapshots
+
+    snapshots.set(commit.snapshotHash, {
+      hash: commit.snapshotHash,
+      data: { key: 'tampered' },
+    })
+
+    expect(core.verifyAll()).toBe(false)
+  })
+
+  it('detects invalid commits during repository verification', () => {
+    const core = Core.create()
+    const commitHash = core.commit({ key: 'value' }, [])
+    const commits = (core as unknown as { commits: Map<string, unknown> })
+      .commits
+
+    commits.set(commitHash, {
+      ...core.getCommit(commitHash),
+      snapshotHash: 'missing-snapshot',
+    })
+
+    expect(core.verifyAll()).toBe(false)
+  })
 })

--- a/packages/object-version-control/src/core.ts
+++ b/packages/object-version-control/src/core.ts
@@ -235,9 +235,17 @@ export class Core<T> {
    * @returns True if all snapshots and commits are valid
    */
   verifyAll(): boolean {
+    return this.verifySnapshotsIntegrity() && this.verifyCommitsIntegrity()
+  }
+
+  private verifySnapshotsIntegrity(): boolean {
     for (const snapshot of this.snapshots.values()) {
       if (!this.verifySnapshot(snapshot)) return false
     }
+    return true
+  }
+
+  private verifyCommitsIntegrity(): boolean {
     for (const commit of this.commits.values()) {
       if (!this.verifyCommit(commit)) return false
     }

--- a/packages/object-version-control/src/treeGraph.spec.ts
+++ b/packages/object-version-control/src/treeGraph.spec.ts
@@ -105,6 +105,10 @@ describe('findCommonAncestor2', () => {
 })
 
 describe('findCommonAncestor', () => {
+  it('should return null if no targets are given', () => {
+    expect(findCommonAncestor([], () => [])).toEqual(null)
+  })
+
   it('should find common ancestor even if three targets are given', () => {
     // dummy getParents function
     const getParents = (hash: string) => {

--- a/packages/object-version-control/src/treeGraph.ts
+++ b/packages/object-version-control/src/treeGraph.ts
@@ -48,23 +48,12 @@ const findCommonAncestorInQueues = <HashLike>(
   visitedB: Set<HashLike>,
   getParents: (hash: HashLike) => HashLike[]
 ): HashLike | null => {
-  if (queueA.length === 0 && queueB.length === 0) return null
+  if (queuesAreEmpty(queueA, queueB)) return null
 
-  const commonFromA = advanceAncestorSearch(
-    queueA,
-    visitedA,
-    visitedB,
-    getParents
-  )
-  if (commonFromA !== null) return commonFromA
-
-  const commonFromB = advanceAncestorSearch(
-    queueB,
-    visitedB,
-    visitedA,
-    getParents
-  )
-  if (commonFromB !== null) return commonFromB
+  const common =
+    advanceAncestorSearch(queueA, visitedA, visitedB, getParents) ??
+    advanceAncestorSearch(queueB, visitedB, visitedA, getParents)
+  if (common !== null) return common
 
   return findCommonAncestorInQueues(
     queueA,
@@ -74,6 +63,11 @@ const findCommonAncestorInQueues = <HashLike>(
     getParents
   )
 }
+
+const queuesAreEmpty = <HashLike>(
+  queueA: HashLike[],
+  queueB: HashLike[]
+): boolean => queueA.length === 0 && queueB.length === 0
 
 /**
  * find the common ancestor of multiple commits
@@ -157,16 +151,8 @@ export const calculateMergeTarget = <HashLike>(
     commonAncestor,
     getParents
   )
-
-  const descendants = new Set<HashLike>()
-  // The target is a descendant if it is visited only once
-  for (const target of targets) {
-    if (visitedCounter.get(target) === 1) {
-      descendants.add(target)
-    }
-  }
-
-  return { commonAncestor, descendants: Array.from(descendants) }
+  const descendants = collectDescendants(targets, visitedCounter)
+  return { commonAncestor, descendants }
 }
 
 /**
@@ -184,10 +170,28 @@ const countAncestorVisits = <HashLike>(
 ): Map<HashLike, number> => {
   const visitedCounter = new Map<HashLike, number>()
   for (const target of targets) {
-    const ancestors = findAncestorsWithin(target, commonAncestor, getParents)
-    for (const ancestor of ancestors) {
-      visitedCounter.set(ancestor, (visitedCounter.get(ancestor) ?? 0) + 1)
-    }
+    incrementAncestorVisits(
+      visitedCounter,
+      findAncestorsWithin(target, commonAncestor, getParents)
+    )
   }
   return visitedCounter
+}
+
+const incrementAncestorVisits = <HashLike>(
+  visitedCounter: Map<HashLike, number>,
+  ancestors: HashLike[]
+): void => {
+  for (const ancestor of ancestors) {
+    visitedCounter.set(ancestor, (visitedCounter.get(ancestor) ?? 0) + 1)
+  }
+}
+
+const collectDescendants = <HashLike>(
+  targets: HashLike[],
+  visitedCounter: Map<HashLike, number>
+): HashLike[] => {
+  return Array.from(
+    new Set(targets.filter((target) => visitedCounter.get(target) === 1))
+  )
 }

--- a/packages/object-version-control/src/treeGraph.ts
+++ b/packages/object-version-control/src/treeGraph.ts
@@ -17,25 +17,13 @@ export const findCommonAncestor2 = <HashLike>(
 
   const queueA: HashLike[] = [hashA]
   const queueB: HashLike[] = [hashB]
-
-  while (queueA.length > 0 || queueB.length > 0) {
-    const commonFromA = advanceAncestorSearch(
-      queueA,
-      visitedA,
-      visitedB,
-      getParents
-    )
-    if (commonFromA !== null) return commonFromA
-
-    const commonFromB = advanceAncestorSearch(
-      queueB,
-      visitedB,
-      visitedA,
-      getParents
-    )
-    if (commonFromB !== null) return commonFromB
-  }
-  return null
+  return findCommonAncestorInQueues(
+    queueA,
+    visitedA,
+    queueB,
+    visitedB,
+    getParents
+  )
 }
 
 const advanceAncestorSearch = <HashLike>(
@@ -51,6 +39,40 @@ const advanceAncestorSearch = <HashLike>(
   visited.add(current)
   queue.push(...getParents(current))
   return null
+}
+
+const findCommonAncestorInQueues = <HashLike>(
+  queueA: HashLike[],
+  visitedA: Set<HashLike>,
+  queueB: HashLike[],
+  visitedB: Set<HashLike>,
+  getParents: (hash: HashLike) => HashLike[]
+): HashLike | null => {
+  if (queueA.length === 0 && queueB.length === 0) return null
+
+  const commonFromA = advanceAncestorSearch(
+    queueA,
+    visitedA,
+    visitedB,
+    getParents
+  )
+  if (commonFromA !== null) return commonFromA
+
+  const commonFromB = advanceAncestorSearch(
+    queueB,
+    visitedB,
+    visitedA,
+    getParents
+  )
+  if (commonFromB !== null) return commonFromB
+
+  return findCommonAncestorInQueues(
+    queueA,
+    visitedA,
+    queueB,
+    visitedB,
+    getParents
+  )
 }
 
 /**

--- a/packages/object-version-control/src/treeGraph.ts
+++ b/packages/object-version-control/src/treeGraph.ts
@@ -19,22 +19,37 @@ export const findCommonAncestor2 = <HashLike>(
   const queueB: HashLike[] = [hashB]
 
   while (queueA.length > 0 || queueB.length > 0) {
-    if (queueA.length > 0) {
-      // biome-ignore lint/style/noNonNullAssertion: already checked by queueA.length > 0
-      const currentA = queueA.shift()!
-      if (visitedB.has(currentA)) return currentA
-      visitedA.add(currentA)
-      queueA.push(...getParents(currentA))
-    }
+    const commonFromA = advanceAncestorSearch(
+      queueA,
+      visitedA,
+      visitedB,
+      getParents
+    )
+    if (commonFromA !== null) return commonFromA
 
-    if (queueB.length > 0) {
-      // biome-ignore lint/style/noNonNullAssertion: already checked by queueB.length > 0
-      const currentB = queueB.shift()!
-      if (visitedA.has(currentB)) return currentB
-      visitedB.add(currentB)
-      queueB.push(...getParents(currentB))
-    }
+    const commonFromB = advanceAncestorSearch(
+      queueB,
+      visitedB,
+      visitedA,
+      getParents
+    )
+    if (commonFromB !== null) return commonFromB
   }
+  return null
+}
+
+const advanceAncestorSearch = <HashLike>(
+  queue: HashLike[],
+  visited: Set<HashLike>,
+  otherVisited: Set<HashLike>,
+  getParents: (hash: HashLike) => HashLike[]
+): HashLike | null => {
+  if (queue.length === 0) return null
+  // biome-ignore lint/style/noNonNullAssertion: already checked by queue.length > 0
+  const current = queue.shift()!
+  if (otherVisited.has(current)) return current
+  visited.add(current)
+  queue.push(...getParents(current))
   return null
 }
 

--- a/packages/object-version-control/src/treeGraph.ts
+++ b/packages/object-version-control/src/treeGraph.ts
@@ -11,63 +11,123 @@ export const findCommonAncestor2 = <HashLike>(
   hashA: HashLike,
   hashB: HashLike,
   getParents: (hash: HashLike) => HashLike[]
-): HashLike | null => {
-  const visitedA = new Set<HashLike>()
-  const visitedB = new Set<HashLike>()
-
-  const queueA: HashLike[] = [hashA]
-  const queueB: HashLike[] = [hashB]
-  return findCommonAncestorInQueues(
-    queueA,
-    visitedA,
-    queueB,
-    visitedB,
+): HashLike | null =>
+  findCommonAncestorFromStates(
+    createAncestorSearchState(hashA),
+    createAncestorSearchState(hashB),
     getParents
   )
+
+type AncestorSearchState<HashLike> = {
+  queue: HashLike[]
+  index: number
+  visited: Set<HashLike>
 }
 
-const advanceAncestorSearch = <HashLike>(
-  queue: HashLike[],
-  visited: Set<HashLike>,
-  otherVisited: Set<HashLike>,
+const createAncestorSearchState = <HashLike>(
+  hash: HashLike
+): AncestorSearchState<HashLike> => ({
+  queue: [hash],
+  index: 0,
+  visited: new Set<HashLike>(),
+})
+
+const hasQueuedNodes = <HashLike>(
+  state: AncestorSearchState<HashLike>
+): boolean => state.index < state.queue.length
+
+const advanceAncestorSearchState = <HashLike>(
+  state: AncestorSearchState<HashLike>,
+  otherVisited: ReadonlySet<HashLike>,
+  getParents: (hash: HashLike) => HashLike[]
+): {
+  state: AncestorSearchState<HashLike>
+  common: HashLike | null
+} => {
+  if (!hasQueuedNodes(state)) {
+    return { state, common: null }
+  }
+
+  const current = state.queue[state.index]
+  if (current === undefined) {
+    return { state, common: null }
+  }
+  if (otherVisited.has(current)) {
+    return {
+      state: { ...state, index: state.index + 1 },
+      common: current,
+    }
+  }
+
+  return {
+    state: {
+      queue: [...state.queue, ...getParents(current)],
+      index: state.index + 1,
+      visited: new Set(state.visited).add(current),
+    },
+    common: null,
+  }
+}
+
+const advanceAncestorSearchPair = <HashLike>(
+  stateA: AncestorSearchState<HashLike>,
+  stateB: AncestorSearchState<HashLike>,
+  getParents: (hash: HashLike) => HashLike[]
+): {
+  stateA: AncestorSearchState<HashLike>
+  stateB: AncestorSearchState<HashLike>
+  common: HashLike | null
+} => {
+  const advancedA = advanceAncestorSearchState(
+    stateA,
+    stateB.visited,
+    getParents
+  )
+  if (advancedA.common !== null) {
+    return {
+      stateA: advancedA.state,
+      stateB,
+      common: advancedA.common,
+    }
+  }
+
+  const advancedB = advanceAncestorSearchState(
+    stateB,
+    advancedA.state.visited,
+    getParents
+  )
+  return {
+    stateA: advancedA.state,
+    stateB: advancedB.state,
+    common: advancedB.common,
+  }
+}
+
+const hasQueuedSearchStates = <HashLike>(
+  stateA: AncestorSearchState<HashLike>,
+  stateB: AncestorSearchState<HashLike>
+): boolean => hasQueuedNodes(stateA) || hasQueuedNodes(stateB)
+
+const findCommonAncestorFromStates = <HashLike>(
+  stateA: AncestorSearchState<HashLike>,
+  stateB: AncestorSearchState<HashLike>,
   getParents: (hash: HashLike) => HashLike[]
 ): HashLike | null => {
-  if (queue.length === 0) return null
-  // biome-ignore lint/style/noNonNullAssertion: already checked by queue.length > 0
-  const current = queue.shift()!
-  if (otherVisited.has(current)) return current
-  visited.add(current)
-  queue.push(...getParents(current))
+  let currentStateA = stateA
+  let currentStateB = stateB
+
+  while (hasQueuedSearchStates(currentStateA, currentStateB)) {
+    const advanced = advanceAncestorSearchPair(
+      currentStateA,
+      currentStateB,
+      getParents
+    )
+    if (advanced.common !== null) return advanced.common
+    currentStateA = advanced.stateA
+    currentStateB = advanced.stateB
+  }
   return null
 }
-
-const findCommonAncestorInQueues = <HashLike>(
-  queueA: HashLike[],
-  visitedA: Set<HashLike>,
-  queueB: HashLike[],
-  visitedB: Set<HashLike>,
-  getParents: (hash: HashLike) => HashLike[]
-): HashLike | null => {
-  if (queuesAreEmpty(queueA, queueB)) return null
-
-  const common =
-    advanceAncestorSearch(queueA, visitedA, visitedB, getParents) ??
-    advanceAncestorSearch(queueB, visitedB, visitedA, getParents)
-  if (common !== null) return common
-
-  return findCommonAncestorInQueues(
-    queueA,
-    visitedA,
-    queueB,
-    visitedB,
-    getParents
-  )
-}
-
-const queuesAreEmpty = <HashLike>(
-  queueA: HashLike[],
-  queueB: HashLike[]
-): boolean => queueA.length === 0 && queueB.length === 0
 
 /**
  * find the common ancestor of multiple commits
@@ -167,24 +227,35 @@ const countAncestorVisits = <HashLike>(
   targets: HashLike[],
   commonAncestor: HashLike,
   getParents: (hash: HashLike) => HashLike[]
+): Map<HashLike, number> =>
+  targets.reduce(
+    (visitedCounter, target) =>
+      mergeAncestorVisitCounts(
+        visitedCounter,
+        countAncestors(findAncestorsWithin(target, commonAncestor, getParents))
+      ),
+    new Map<HashLike, number>()
+  )
+
+const countAncestors = <HashLike>(
+  ancestors: HashLike[]
 ): Map<HashLike, number> => {
-  const visitedCounter = new Map<HashLike, number>()
-  for (const target of targets) {
-    incrementAncestorVisits(
-      visitedCounter,
-      findAncestorsWithin(target, commonAncestor, getParents)
-    )
+  const counts = new Map<HashLike, number>()
+  for (const ancestor of ancestors) {
+    counts.set(ancestor, (counts.get(ancestor) ?? 0) + 1)
   }
-  return visitedCounter
+  return counts
 }
 
-const incrementAncestorVisits = <HashLike>(
-  visitedCounter: Map<HashLike, number>,
-  ancestors: HashLike[]
-): void => {
-  for (const ancestor of ancestors) {
-    visitedCounter.set(ancestor, (visitedCounter.get(ancestor) ?? 0) + 1)
+const mergeAncestorVisitCounts = <HashLike>(
+  left: Map<HashLike, number>,
+  right: Map<HashLike, number>
+): Map<HashLike, number> => {
+  const merged = new Map(left)
+  for (const [ancestor, count] of right) {
+    merged.set(ancestor, (merged.get(ancestor) ?? 0) + count)
   }
+  return merged
 }
 
 const collectDescendants = <HashLike>(

--- a/packages/object-version-control/src/treeGraph.ts
+++ b/packages/object-version-control/src/treeGraph.ts
@@ -48,10 +48,8 @@ const advanceAncestorSearchState = <HashLike>(
     return { state, common: null }
   }
 
-  const current = state.queue[state.index]
-  if (current === undefined) {
-    return { state, common: null }
-  }
+  // biome-ignore lint/style/noNonNullAssertion: guarded by hasQueuedNodes(state)
+  const current = state.queue[state.index]!
   if (otherVisited.has(current)) {
     return {
       state: { ...state, index: state.index + 1 },

--- a/packages/word-stats/src/index.ts
+++ b/packages/word-stats/src/index.ts
@@ -24,10 +24,7 @@ export const wordCount = (documents: Document[]): WordScore => {
   const wordCounts: WordScore = {}
   for (const document of documents) {
     for (const word of document) {
-      if (!wordCounts[word]) {
-        wordCounts[word] = 0
-      }
-      wordCounts[word]++
+      incrementWordScore(wordCounts, word)
     }
   }
   return wordCounts

--- a/packages/word-stats/src/index.ts
+++ b/packages/word-stats/src/index.ts
@@ -2,26 +2,31 @@ type Word = string
 type Document = Word[]
 type WordScore = { [word: Word]: number }
 
-const incrementWordScore = (scores: WordScore, word: Word): void => {
-  scores[word] = (scores[word] ?? 0) + 1
+const countWords = (words: Iterable<Word>): WordScore => {
+  const counts: WordScore = {}
+  for (const word of words) {
+    counts[word] = (counts[word] ?? 0) + 1
+  }
+  return counts
 }
 
-const countWordDocumentFrequencies = (documents: Document[]): WordScore => {
-  const wordDocumentCounts: WordScore = {}
-  for (const document of documents) {
-    incrementDocumentWordFrequencies(wordDocumentCounts, document)
+const mergeWordScores = (left: WordScore, right: WordScore): WordScore => {
+  const merged: WordScore = { ...left }
+  for (const word in right) {
+    merged[word] = (merged[word] ?? 0) + right[word]
   }
-  return wordDocumentCounts
+  return merged
 }
 
-const incrementDocumentWordFrequencies = (
-  scores: WordScore,
-  document: Document
-): void => {
-  for (const word of extractUniqueWords(document)) {
-    incrementWordScore(scores, word)
-  }
-}
+const countWordDocumentFrequencies = (documents: Document[]): WordScore =>
+  documents.reduce(
+    (wordDocumentCounts, document) =>
+      mergeWordScores(
+        wordDocumentCounts,
+        countWords(extractUniqueWords(document))
+      ),
+    {}
+  )
 
 /**
  * Count the number of words in the documents
@@ -38,13 +43,10 @@ const incrementDocumentWordFrequencies = (
  * @returns A dictionary of words and their counts
  */
 export const wordCount = (documents: Document[]): WordScore => {
-  const wordCounts: WordScore = {}
-  for (const document of documents) {
-    for (const word of document) {
-      incrementWordScore(wordCounts, word)
-    }
-  }
-  return wordCounts
+  return documents.reduce(
+    (wordCounts, document) => mergeWordScores(wordCounts, countWords(document)),
+    {}
+  )
 }
 
 /**

--- a/packages/word-stats/src/index.ts
+++ b/packages/word-stats/src/index.ts
@@ -6,6 +6,23 @@ const incrementWordScore = (scores: WordScore, word: Word): void => {
   scores[word] = (scores[word] ?? 0) + 1
 }
 
+const countWordDocumentFrequencies = (documents: Document[]): WordScore => {
+  const wordDocumentCounts: WordScore = {}
+  for (const document of documents) {
+    incrementDocumentWordFrequencies(wordDocumentCounts, document)
+  }
+  return wordDocumentCounts
+}
+
+const incrementDocumentWordFrequencies = (
+  scores: WordScore,
+  document: Document
+): void => {
+  for (const word of extractUniqueWords(document)) {
+    incrementWordScore(scores, word)
+  }
+}
+
 /**
  * Count the number of words in the documents
  * @example
@@ -78,19 +95,11 @@ export const computeInverseDocumentFrequency = (
   documents: Document[]
 ): WordScore => {
   const documentCount = documents.length
-  const wordDocumentCounts: WordScore = {}
-  for (const document of documents) {
-    const words = extractUniqueWords(document)
-    for (const word of words) {
-      incrementWordScore(wordDocumentCounts, word)
-    }
-  }
-  const wordIDFs: WordScore = {}
-  for (const word in wordDocumentCounts) {
-    const count = wordDocumentCounts[word]
-    wordIDFs[word] = Math.log(documentCount / count)
-  }
-  return wordIDFs
+  return Object.fromEntries(
+    Object.entries(countWordDocumentFrequencies(documents)).map(
+      ([word, count]) => [word, Math.log(documentCount / count)]
+    )
+  )
 }
 
 /**

--- a/packages/word-stats/src/index.ts
+++ b/packages/word-stats/src/index.ts
@@ -2,6 +2,10 @@ type Word = string
 type Document = Word[]
 type WordScore = { [word: Word]: number }
 
+const incrementWordScore = (scores: WordScore, word: Word): void => {
+  scores[word] = (scores[word] ?? 0) + 1
+}
+
 /**
  * Count the number of words in the documents
  * @example
@@ -81,10 +85,7 @@ export const computeInverseDocumentFrequency = (
   for (const document of documents) {
     const words = extractUniqueWords(document)
     for (const word of words) {
-      if (!wordDocumentCounts[word]) {
-        wordDocumentCounts[word] = 0
-      }
-      wordDocumentCounts[word]++
+      incrementWordScore(wordDocumentCounts, word)
     }
   }
   const wordIDFs: WordScore = {}


### PR DESCRIPTION
## Summary
- add a Biome cognitive complexity rule for the workspace
- tighten the maximum allowed complexity in follow-up commits from 14 down to 3
- refactor the flagged functions and one test helper path to keep the repository green at each step

## Validation
- `bun run lint`
- `bun run test`

## Notes
- this PR was intentionally built as a stack of small follow-up commits after the initial minimum-threshold PR state
