### PR TITLE
Checkout synced HEAD after push and pull

### DIFF
--- a/packages/object-version-control/src/ovc.spec.ts
+++ b/packages/object-version-control/src/ovc.spec.ts
@@ -119,10 +119,16 @@ describe('ObjectVersionControl', () => {
     ovc1.commit({ key: 'value' })
     const [ovc2, syncState] = ovc1.fullClone()
     const commitHash2 = ovc1.commit({ key: 'value', newKey: 'newValue' })
-    ovc1.push(ovc2, syncState)
+    const nextSyncState = ovc1.push(ovc2, syncState)
     const ovc2Commit2 = ovc2.getCommit(commitHash2)
     const ovc1Commit2 = ovc1.getCommit(commitHash2)
     expect(ovc2Commit2).toEqual(ovc1Commit2)
+    expect(ovc2.getHead()).toEqual(ovc1Commit2)
+    expect(ovc2.getCurrentData()).toEqual({ key: 'value', newKey: 'newValue' })
+    expect(nextSyncState).toEqual({
+      local: commitHash2,
+      remote: commitHash2,
+    })
   })
 
   it('should pull some commits from another OVC', () => {
@@ -130,10 +136,16 @@ describe('ObjectVersionControl', () => {
     ovc1.commit({ key: 'value' })
     const [ovc2, syncState] = ovc1.fullClone()
     const commitHash2 = ovc1.commit({ key: 'value', newKey: 'newValue' })
-    ovc2.pull(ovc1, syncState)
+    const nextSyncState = ovc2.pull(ovc1, syncState)
     const ovc2Commit2 = ovc2.getCommit(commitHash2)
     const ovc1Commit2 = ovc1.getCommit(commitHash2)
     expect(ovc2Commit2).toEqual(ovc1Commit2)
+    expect(ovc2.getHead()).toEqual(ovc1Commit2)
+    expect(ovc2.getCurrentData()).toEqual({ key: 'value', newKey: 'newValue' })
+    expect(nextSyncState).toEqual({
+      local: commitHash2,
+      remote: commitHash2,
+    })
   })
 
   it('should throw an error when checking out a non-existent commit', () => {

--- a/packages/object-version-control/src/ovc.ts
+++ b/packages/object-version-control/src/ovc.ts
@@ -244,6 +244,7 @@ export class ObjectVersionControl<T> {
     syncItems: SyncItems<T>
   ): SyncHead {
     remoteOvc.base.sync(syncItems)
+    if (this.head !== null) remoteOvc.checkout(this.head)
     return {
       local: this.head,
       remote: remoteOvc.head,
@@ -274,6 +275,7 @@ export class ObjectVersionControl<T> {
     syncItems: SyncItems<T>
   ): SyncHead {
     this.base.sync(syncItems)
+    if (remoteOvc.head !== null) this.checkout(remoteOvc.head)
     return {
       local: this.head,
       remote: remoteOvc.head,


### PR DESCRIPTION
## Summary

Update object-version-control sync operations so receivers check out the transferred HEAD after push or pull.

## Details

- After `push`, the remote repository checks out the local HEAD that was just synced.
- After `pull`, the local repository checks out the remote HEAD that was just synced.
- Extend push/pull tests to assert receiver HEAD, current data, and returned sync head state.

## Verification

- `bun install`
- `bun run test packages/object-version-control/src/ovc.spec.ts`
- `bun run lint`
- `bun run typecheck`
- `git diff --check`
