### PR TITLE
Pin remaining external action refs to commit SHAs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,13 +18,13 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.11
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           # https://nodejs.org/en/about/previous-releases
           node-version: '24.x'

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -5,4 +5,4 @@ permissions:
   contents: read
 jobs:
   check:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@9108d679c02a52824376afcf071715fdaaa2a4e4 # main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,16 +22,16 @@ jobs:
         node-version: [20.x, 22.x, 24.x]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.11
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -52,7 +52,7 @@ jobs:
 
       - name: Measure build size
         if: matrix.node-version == '24.x'
-        uses: kitsuyui/gh-build-size@v0.1.2
+        uses: kitsuyui/gh-build-size@97ad8d5f4fff8ba676a5c614822adacab32780e3 # v0.1.2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       

--- a/.github/workflows/typedoc.yml
+++ b/.github/workflows/typedoc.yml
@@ -18,13 +18,13 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.11
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           # https://nodejs.org/en/about/previous-releases
           node-version: 24.x
@@ -33,7 +33,7 @@ jobs:
 
       - run: bun run typedoc
 
-      - uses: actions/upload-pages-artifact@v4
+      - uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
         id: deployment
         with:
           path: ./build/typedocs
@@ -53,4 +53,4 @@ jobs:
       # https://github.com/actions/deploy-pages
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4


### PR DESCRIPTION
## Summary
- Replace tag/branch refs in `release.yml`, `spellcheck.yml`, `test.yml`, and `typedoc.yml` with 40-char commit SHAs, keeping the original tag/branch as a trailing comment.
- Follow the existing pinning style established in `octocov.yml` (PR #922), `gh-counter.yml` / `happy.yml` (PR #923), and `gitignore-in.yml` (PR #921).
- After this PR, every external `uses:` in `.github/workflows/` is SHA-pinned so the supply-chain input of CI/CD is no longer movable upstream.

## Pinned refs
| ref | tag/branch | pinned SHA |
| --- | --- | --- |
| `actions/checkout` | `v6` | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` |
| `oven-sh/setup-bun` | `v2` | `0c5077e51419868618aeaa5fe8019c62421857d6` |
| `actions/setup-node` | `v6` | `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` |
| `actions/upload-pages-artifact` | `v4` | `7b1f4a764d45c48632c6b24a0339c27f5614fb0b` |
| `actions/deploy-pages` | `v4` | `d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e` |
| `kitsuyui/gh-build-size` | `v0.1.2` | `97ad8d5f4fff8ba676a5c614822adacab32780e3` |
| `kitsuyui/gh-actions-workflows/.../spellcheck.yml` | `main` | `9108d679c02a52824376afcf071715fdaaa2a4e4` |

## Test plan
- [ ] CI (test / typedoc / spellcheck / release) passes on this branch.
- [ ] `grep -nE 'uses:' .github/workflows/*.yml` shows every external ref pinned to a 40-char SHA.