### PR TITLE
Add workflow concurrency controls

### DIFF
--- a/.github/workflows/gh-counter.yml
+++ b/.github/workflows/gh-counter.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/happy.yml
+++ b/.github/workflows/happy.yml
@@ -1,6 +1,11 @@
 name: happy-commit
 on:
   - pull_request
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/octocov.yml
+++ b/.github/workflows/octocov.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+
 env:
   # Temporary workaround for JavaScript actions that still default to Node 20 on runners.
   # Remove this once the affected actions have migrated, otherwise this may become a future warning source itself.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,10 @@ on:
     # "released" events are emitted either when directly be released or be edited from pre-released.
     types: [prereleased, released]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -42,7 +46,7 @@ jobs:
           git config user.email "dummy@dummy"
           git config user.name "dummy"
           # dummy tag for dry-run
-          git tag v999.999.999-rc.$GITHUB_RUN_NUMBER
+          git tag "v999.999.999-rc.${GITHUB_RUN_NUMBER}"
 
       - name: set git tag version
         run: |

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,6 +1,11 @@
 name: Spellcheck
 on:
   - pull_request
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,11 @@ on:
   push:
     branches:
       - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/typedoc.yml
+++ b/.github/workflows/typedoc.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+
 env:
   # Temporary workaround for JavaScript actions that still default to Node 20 on runners.
   # Remove this once the affected actions have migrated, otherwise this may become a future warning source itself.


### PR DESCRIPTION
## Summary
- Add workflow-level concurrency groups to the repository's pull_request and push workflows so superseded runs are canceled per branch or PR.
- Keep release events grouped but not canceled by limiting cancel-in-progress to pull_request and push events.
- Quote the dummy release tag in `.github/workflows/release.yml` so actionlint can validate the touched workflow.

## Checks
- `actionlint`
- `git diff --check`
- `bun install --frozen-lockfile`
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `bun run validate`
- `bun run test`
- `bun run typedoc`
