### PR TITLE
ci: cache bun package dependencies in octocov and test workflows

### DIFF
--- a/.github/workflows/octocov.yml
+++ b/.github/workflows/octocov.yml
@@ -32,6 +32,14 @@ jobs:
         with:
           node-version: 24.x
 
+      - name: Cache bun dependencies
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,14 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      - name: Cache bun dependencies
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
 


### PR DESCRIPTION
## Summary

Add an explicit `actions/cache` step for `~/.bun/install/cache` to the `octocov.yml` and `test.yml` workflows. The cache is keyed on `bun.lock` so that the bun package store is reused between CI runs sharing the same resolved dependencies.

## Motivation

`actions/setup-node` does not support bun as a cache manager, so the standard `cache: 'pnpm'` / `cache: 'npm'` approach is not applicable here. A separate `actions/cache` step targeting bun's global install cache achieves the same effect: subsequent runs restore the cached store and `bun install --frozen-lockfile` skips re-downloading resolved packages.

## Verification

- `actionlint` passes on both modified workflow files
- `git diff --check` reports no whitespace issues