### PR TITLE
fix: use structuredClone in deepCopy to correctly handle Date, Map, Set, and BigInt

### DIFF
--- a/packages/object-version-control/src/utils.spec.ts
+++ b/packages/object-version-control/src/utils.spec.ts
@@ -10,6 +10,36 @@ describe('deepCopy', () => {
     expect(copied).not.toBe(obj)
     expect(copied.b).not.toBe(obj.b)
   })
+
+  it('preserves Date objects', () => {
+    const obj = { d: new Date('2024-01-01') }
+    const copied = deepCopy(obj)
+    expect(copied.d).toBeInstanceOf(Date)
+    expect(copied.d.getTime()).toBe(obj.d.getTime())
+    expect(copied.d).not.toBe(obj.d)
+  })
+
+  it('preserves Map objects', () => {
+    const m = new Map([['key', 'value']])
+    const copied = deepCopy(m)
+    expect(copied).toBeInstanceOf(Map)
+    expect(copied.get('key')).toBe('value')
+    expect(copied).not.toBe(m)
+  })
+
+  it('preserves Set objects', () => {
+    const s = new Set([1, 2, 3])
+    const copied = deepCopy(s)
+    expect(copied).toBeInstanceOf(Set)
+    expect(copied.has(1)).toBe(true)
+    expect(copied).not.toBe(s)
+  })
+
+  it('preserves BigInt values', () => {
+    const obj = { n: 9007199254740993n }
+    const copied = deepCopy(obj)
+    expect(copied.n).toBe(obj.n)
+  })
 })
 
 describe('generateHash', () => {

--- a/packages/object-version-control/src/utils.ts
+++ b/packages/object-version-control/src/utils.ts
@@ -11,10 +11,12 @@ export const generateHash = (text: string): string => {
 /**
  * Deep copy an object
  * @remarks
- * This function is not suitable for copying objects with functions, symbols, or circular references.
+ * This function is not suitable for copying objects with function values or symbol-keyed properties
+ * (throws DataCloneError). Handles `Date`, `Map`, `Set`, `BigInt`, circular references, and
+ * `undefined` values correctly.
  * @param obj
  * @returns copied object
  */
 export const deepCopy = <T>(obj: T): T => {
-  return JSON.parse(JSON.stringify(obj))
+  return structuredClone(obj)
 }


### PR DESCRIPTION
## Summary

Replace `JSON.parse(JSON.stringify(obj))` with `structuredClone()` in `deepCopy`.

The previous implementation silently corrupted several types:

| Type | Before | After |
|------|--------|-------|
| `Date` | Converted to ISO string — type information lost | Preserved as `Date` |
| `Map` | Converted to `{}` — all entries lost | Preserved as `Map` |
| `Set` | Converted to `[]` — all entries lost | Preserved as `Set` |
| `BigInt` | Threw `TypeError` at runtime | Preserved as `BigInt` |
| `undefined` properties | Silently dropped | Preserved |
| Circular references | Threw at runtime | Handled correctly |

`structuredClone` is available in Node.js 17+ and in `lib.dom.d.ts` / `lib.esnext.d.ts` since TypeScript 4.7 (this repo uses `@types/node ^24` and `lib: ["esnext", "dom"]`).

Objects with **function values or symbol-keyed properties** still throw `DataCloneError` — this is documented in the updated `@remarks`.

## Changes

- `packages/object-version-control/src/utils.ts`: Replace implementation, update docstring
- `packages/object-version-control/src/utils.spec.ts`: Add tests for `Date`, `Map`, `Set`, `BigInt`

## Verification

All tests pass (`bun run test`). Lint and typecheck clean (`bun run lint`, `bun run typecheck`).
