### PR TITLE
fix: unify logging style in errorLogger to use JSON.stringify

### DIFF
--- a/packages/debug/src/sameBehavior/errorFunctions/index.spec.ts
+++ b/packages/debug/src/sameBehavior/errorFunctions/index.spec.ts
@@ -10,16 +10,16 @@ describe('error functions', () => {
         .mockImplementation(() => {})
 
       const args = [1, 2, 3]
-      const resultA = 'resultA'
-      const resultB = 'resultB'
+      const resultA = { value: 'resultA' }
+      const resultB = { value: 'resultB' }
 
       errorLogger(args, resultA, resultB)
 
       expect(consoleErrorSpy).toHaveBeenCalledWith(
-        'Functions exhibit different behavior!\n Args: %s\n Result A: %s\n Result B: %s',
-        args,
-        resultA,
-        resultB
+        'Functions exhibit different behavior!\n' +
+          `Arguments: ${JSON.stringify(args)}\n` +
+          `Result A: ${JSON.stringify(resultA)}\n` +
+          `Result B: ${JSON.stringify(resultB)}`
       )
 
       consoleErrorSpy.mockRestore()

--- a/packages/debug/src/sameBehavior/errorFunctions/index.ts
+++ b/packages/debug/src/sameBehavior/errorFunctions/index.ts
@@ -9,12 +9,13 @@ export const errorLogger = <A extends unknown[], S>(
   resultA: S,
   resultB: S
 ): void => {
-  console.error(
-    'Functions exhibit different behavior!\n Args: %s\n Result A: %s\n Result B: %s',
-    args,
-    resultA,
-    resultB
-  )
+  const message = [
+    'Functions exhibit different behavior!',
+    `Arguments: ${JSON.stringify(args)}`,
+    `Result A: ${JSON.stringify(resultA)}`,
+    `Result B: ${JSON.stringify(resultB)}`,
+  ].join('\n')
+  console.error(message)
 }
 
 /**


### PR DESCRIPTION
## Problem

`errorLogger` and `errorThrower` in `packages/debug/src/sameBehavior/errorFunctions/index.ts` use different serialization strategies for the same set of arguments:

- `errorLogger` uses printf-style `%s` placeholders with `console.error`. When objects are passed, `%s` coerces them to `"[object Object]"`, hiding the actual content.
- `errorThrower` uses `JSON.stringify` in template literals, producing readable structured output.

Additionally, passing large objects via `%s` to `console.error` can produce unbounded output.

## Fix

Rewrite `errorLogger` to use the same `JSON.stringify` + template literal pattern as `errorThrower`:

```ts
const message = [
  'Functions exhibit different behavior!',
  `Arguments: ${JSON.stringify(args)}`,
  `Result A: ${JSON.stringify(resultA)}`,
  `Result B: ${JSON.stringify(resultB)}`,
].join('\n')
console.error(message)
```

The test is updated to verify the new format using an object argument (rather than a plain string), which also proves that object contents are now visible in the log.

## Verification

- `bun run format`: no changes
- `bun run lint`: no findings
- `bun run typecheck`: no errors
- `bun run test`: 217/217 passed
- `knip`: 10 pre-existing findings in unrelated files; no new findings from this change
