### PR TITLE
fix: replace bitwise operators with arithmetic in bitReversalIndex for n>=32 safety

### DIFF
--- a/packages/incremental-color-palette/src/bitReversalPermutation.spec.ts
+++ b/packages/incremental-color-palette/src/bitReversalPermutation.spec.ts
@@ -13,4 +13,20 @@ describe('bitReversalIndex', () => {
     expect(bitReversalIndex(2, 2)).toBe(1)
     expect(bitReversalIndex(2, 3)).toBe(3)
   })
+
+  it('should handle n=31 boundary without overflow', () => {
+    // bit 0 in 31-bit space maps to bit 30
+    expect(bitReversalIndex(31, 0)).toBe(0)
+    expect(bitReversalIndex(31, 1)).toBe(2 ** 30)
+    // all bits set maps to all bits set (palindrome)
+    expect(bitReversalIndex(31, 2 ** 31 - 1)).toBe(2 ** 31 - 1)
+  })
+
+  it('should handle n=32 boundary without Int32 sign-bit overflow', () => {
+    // bit 0 in 32-bit space maps to bit 31
+    // original code: 1 << 31 = -2147483648 (Int32 sign bit); arithmetic: 2**31 = 2147483648
+    expect(bitReversalIndex(32, 0)).toBe(0)
+    expect(bitReversalIndex(32, 1)).toBe(2 ** 31)
+    expect(bitReversalIndex(32, 2 ** 31)).toBe(1)
+  })
 })

--- a/packages/incremental-color-palette/src/bitReversalPermutation.ts
+++ b/packages/incremental-color-palette/src/bitReversalPermutation.ts
@@ -13,8 +13,8 @@ export const bitReversalIndex = (
   let reversedIndex = 0
 
   for (let i = 0; i < bits; i++) {
-    if (index & (1 << i)) {
-      reversedIndex |= 1 << (bits - 1 - i)
+    if (Math.floor(index / 2 ** i) % 2 !== 0) {
+      reversedIndex += 2 ** (bits - 1 - i)
     }
   }
 


### PR DESCRIPTION
## Summary

`bitReversalIndex` used JavaScript's 32-bit bitwise operators (`<<`, `|=`, `&`) to compute bit-reversal permutation indices. JavaScript coerces operands to signed Int32 before bitwise operations, causing incorrect results when `n >= 32`:
- `1 << 31` returns `-2147483648` (sign bit overflow) instead of `2147483648`
- `1 << i` for `i >= 32` wraps around to `1 << (i & 0x1f)`, producing a wrong bit pattern

## Change

Replaced all bitwise operators with arithmetic equivalents:
- `index & (1 << i)` → `Math.floor(index / 2 ** i) % 2 !== 0`
- `reversedIndex |= 1 << (bits - 1 - i)` → `reversedIndex += 2 ** (bits - 1 - i)`

These arithmetic operations use JavaScript's IEEE 754 floating-point representation, which correctly handles integers up to 2^53.

## Verification

Added boundary tests for `n=31` and `n=32` that demonstrate the original code's failure mode and confirm the fix produces correct results. All existing tests continue to pass.

## Trade-offs

The arithmetic approach is slightly less familiar than bitwise idioms, but it correctly handles any `n` within JavaScript's safe integer range. The practical call site (`circularPut.ts`) passes `m = floor(log2(n+1))` as the bit count, so `n >= 32` is unreachable in current usage — however the function's type signature (`uint0toInf`) makes no such guarantee.
