### PR TITLE
fix: use canonical key-sorted serialization in computeHash for stable snapshot deduplication

### DIFF
--- a/packages/object-version-control/src/core.spec.ts
+++ b/packages/object-version-control/src/core.spec.ts
@@ -102,4 +102,14 @@ describe('Core', () => {
 
     expect(core.verifyAll()).toBe(false)
   })
+
+  it('deduplicates snapshots for logically equal objects with different key orders', () => {
+    const core = Core.create<Record<string, number>>()
+    const h1 = core.commit({ a: 1, b: 2 }, [])
+    const h2 = core.commit({ b: 2, a: 1 }, [h1])
+
+    const c1 = core.getCommit(h1)
+    const c2 = core.getCommit(h2)
+    expect(c1.snapshotHash).toBe(c2.snapshotHash)
+  })
 })

--- a/packages/object-version-control/src/core.ts
+++ b/packages/object-version-control/src/core.ts
@@ -1,5 +1,5 @@
 import { findAncestorsWithin } from './treeGraph'
-import { deepCopy, generateHash } from './utils'
+import { canonicalStringify, deepCopy, generateHash } from './utils'
 
 /**
  * Core class
@@ -35,7 +35,7 @@ export class Core<T> {
 
   // Generate a hash for any given input
   private computeHash(input: unknown): string {
-    return this.hasher(JSON.stringify(input))
+    return this.hasher(canonicalStringify(input))
   }
 
   hasCommit(hash: HashValue): boolean {

--- a/packages/object-version-control/src/utils.spec.ts
+++ b/packages/object-version-control/src/utils.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { deepCopy, generateHash } from './utils'
+import { canonicalStringify, deepCopy, generateHash } from './utils'
 
 describe('deepCopy', () => {
   it('should deep copy an object', () => {
@@ -18,5 +18,38 @@ describe('generateHash', () => {
     expect(hash).toBe(
       '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824'
     )
+  })
+})
+
+describe('canonicalStringify', () => {
+  it('produces the same output regardless of object key insertion order', () => {
+    const a = { a: 1, b: 2 }
+    const b = { b: 2, a: 1 }
+    expect(canonicalStringify(a)).toBe(canonicalStringify(b))
+  })
+
+  it('sorts nested object keys recursively', () => {
+    const a = { z: { y: 1, x: 2 }, m: 3 }
+    const b = { m: 3, z: { x: 2, y: 1 } }
+    expect(canonicalStringify(a)).toBe(canonicalStringify(b))
+  })
+
+  it('preserves array element order', () => {
+    const a = [1, 2, 3]
+    const b = [3, 2, 1]
+    expect(canonicalStringify(a)).not.toBe(canonicalStringify(b))
+  })
+
+  it('handles primitives and null', () => {
+    expect(canonicalStringify(null)).toBe('null')
+    expect(canonicalStringify(42)).toBe('42')
+    expect(canonicalStringify('hello')).toBe('"hello"')
+    expect(canonicalStringify(true)).toBe('true')
+  })
+
+  it('handles arrays of objects with different key orders', () => {
+    const a = [{ b: 2, a: 1 }]
+    const b = [{ a: 1, b: 2 }]
+    expect(canonicalStringify(a)).toBe(canonicalStringify(b))
   })
 })

--- a/packages/object-version-control/src/utils.ts
+++ b/packages/object-version-control/src/utils.ts
@@ -18,3 +18,27 @@ export const generateHash = (text: string): string => {
 export const deepCopy = <T>(obj: T): T => {
   return JSON.parse(JSON.stringify(obj))
 }
+
+/**
+ * Serialize a value to JSON with object keys sorted recursively.
+ * Two values that are logically equal but have different key insertion order
+ * produce the same output string, making this suitable for content-addressed hashing.
+ * Arrays preserve their original element order.
+ * @param value
+ * @returns canonical JSON string
+ */
+export const canonicalStringify = (value: unknown): string => {
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalStringify).join(',')}]`
+  }
+  if (value !== null && typeof value === 'object') {
+    const sorted = Object.keys(value as Record<string, unknown>)
+      .sort()
+      .map((k) => {
+        const v = (value as Record<string, unknown>)[k]
+        return `${JSON.stringify(k)}:${canonicalStringify(v)}`
+      })
+    return `{${sorted.join(',')}}`
+  }
+  return JSON.stringify(value)
+}


### PR DESCRIPTION
## Summary

`computeHash` in the `Core` class used `JSON.stringify(input)` to serialize data before hashing. `JSON.stringify` serializes object keys in insertion order, so two objects with the same logical content but different key order produce different JSON strings and different hashes. This breaks the content-addressed deduplication contract of the snapshot store: `{ a: 1, b: 2 }` and `{ b: 2, a: 1 }` would be stored as separate snapshots.

## Change

Added `canonicalStringify` to `utils.ts`: a recursive serializer that sorts object keys before producing the JSON representation. Arrays preserve their element order (which is semantically significant). `computeHash` now uses `canonicalStringify` instead of `JSON.stringify`.

## Verification

New tests in `utils.spec.ts` cover:
- Same output for objects with different key insertion orders
- Recursive sorting of nested object keys
- Array element order is preserved (not sorted)
- Primitive and null handling

A new test in `core.spec.ts` confirms that committing `{ a: 1, b: 2 }` and then `{ b: 2, a: 1 }` results in the same snapshot hash, demonstrating correct deduplication.

## Trade-offs

This changes the hash function, so any pre-existing serialized state would produce different hashes when re-read. The snapshot store is in-memory with no persistence format in this package, so there is no migration concern. The arithmetic cost of key sorting is `O(k log k)` per object level — negligible for the small objects typical in version-controlled application state.
