### PR TITLE
refactor: convert ambient type declarations to explicit ES module exports in object-version-control

### DIFF
--- a/packages/object-version-control/src/automerge.ts
+++ b/packages/object-version-control/src/automerge.ts
@@ -2,6 +2,7 @@ import { next as automerge } from '@automerge/automerge'
 import * as jsondiffpatch from 'jsondiffpatch'
 
 import type { ObjectVersionControl } from './ovc'
+import type { HashValue } from './types'
 import { deepCopy } from './utils'
 
 /**

--- a/packages/object-version-control/src/core.ts
+++ b/packages/object-version-control/src/core.ts
@@ -1,4 +1,14 @@
 import { findAncestorsWithin } from './treeGraph'
+import type {
+  Commit,
+  CommitInfo,
+  CommitMap,
+  Hasher,
+  HashValue,
+  Snapshot,
+  SnapshotMap,
+  SyncItems,
+} from './types'
 import { canonicalStringify, deepCopy, generateHash } from './utils'
 
 /**

--- a/packages/object-version-control/src/merge.ts
+++ b/packages/object-version-control/src/merge.ts
@@ -1,4 +1,5 @@
 import type { ObjectVersionControl } from './ovc'
+import type { HashValue } from './types'
 
 /**
  * Merge the targets with the Last-Writer-Wins strategy

--- a/packages/object-version-control/src/ovc.ts
+++ b/packages/object-version-control/src/ovc.ts
@@ -1,4 +1,11 @@
 import { Core } from './core'
+import type { Commit, HashValue, Snapshot, SyncHead, SyncItems } from './types'
+
+type MergeResolver<T> = (
+  ovc: ObjectVersionControl<T>,
+  targets: HashValue[],
+  base: HashValue | null
+) => T
 
 type CloneResult<T> = [ObjectVersionControl<T>, SyncHead]
 

--- a/packages/object-version-control/src/types.ts
+++ b/packages/object-version-control/src/types.ts
@@ -1,37 +1,31 @@
-type HashValue = string
-type Timestamp = number // Unix timestamp
+export type HashValue = string
+export type Timestamp = number // Unix timestamp
 
-type Hasher = (data: string) => HashValue
+export type Hasher = (data: string) => HashValue
 
 // Define types for snapshot and commit
-interface Snapshot<T> {
+export interface Snapshot<T> {
   hash: HashValue
   data: T
 }
 
-interface CommitInfo {
+export interface CommitInfo {
   parents: HashValue[]
   snapshotHash: HashValue
   // message: Git has commit messages, but not used in this implementation
 }
 
-type Commit = {
+export type Commit = {
   hash: HashValue
   timestamp: Timestamp
 } & CommitInfo
 
-type CommitMap = Map<HashValue, Commit>
-type SnapshotMap<T> = Map<HashValue, Snapshot<T>>
+export type CommitMap = Map<HashValue, Commit>
+export type SnapshotMap<T> = Map<HashValue, Snapshot<T>>
 
-type MergeResolver<T> = (
-  ovc: ObjectVersionControl<T>,
-  targets: HashValue[],
-  base: HashValue | null
-) => T
+export type DataOnlyMergeResolver<T> = (targets: T[], base: T | null) => T
 
-type DataOnlyMergeResolver<T> = (targets: T[], base: T | null) => T
-
-interface SyncItems<T> {
+export interface SyncItems<T> {
   commits: Commit[]
   snapshots: Snapshot<T>[]
 }
@@ -43,7 +37,7 @@ declare const _syncHeadBrand: unique symbol
  * Valid SyncHead values are only produced by push(), pull(), fullClone(), and shallowClone().
  * The opaque brand prevents construction of arbitrary SyncHead literals.
  */
-interface SyncHead {
+export interface SyncHead {
   readonly [_syncHeadBrand]: undefined
   local: HashValue | null
   remote: HashValue | null


### PR DESCRIPTION
## Summary

`packages/object-version-control/src/types.d.ts` declared all package types (`HashValue`, `Commit`, `Snapshot<T>`, `SyncItems<T>`, etc.) as global ambient declarations. This made the types available in every file without an `import` statement, hiding the real dependency graph from standard tooling (import linters, bundler analysis, dead-code detectors).

## Change

- Replaced `types.d.ts` with `types.ts`, adding explicit `export type` / `export interface` to all declarations
- Added `import type { ... } from './types'` to each consuming file: `core.ts`, `ovc.ts`, `automerge.ts`, `merge.ts`
- `MergeResolver<T>` — which references `ObjectVersionControl<T>` and would create a circular import if placed in `types.ts` — is defined as a local type in `ovc.ts` where it is used

## Verification

All existing tests pass. `tsc --strict` succeeds. No linter warnings introduced.

## Trade-offs

`DataOnlyMergeResolver<T>` was previously unused but declared globally. It is now exported from `types.ts` with an explicit `export type`, making its availability and origin discoverable. `MergeResolver<T>` is not re-exported publicly from `index.ts` (unchanged from before). If callers outside the package need these resolver types, a future PR can add them to the public API surface.
