### PR TITLE
fix: correct clampMinAndMax to use MIN_SAFE_INTEGER instead of MIN_VALUE

### DIFF
--- a/packages/mymath/src/clamp.spec.ts
+++ b/packages/mymath/src/clamp.spec.ts
@@ -17,12 +17,21 @@ describe('clamp', () => {
 })
 
 describe('clampMinAndMax', () => {
-  it('should clamp value to Number.MIN_VALUE and Number.MAX_VALUE', () => {
+  it('should clamp value to Number.MIN_SAFE_INTEGER and Number.MAX_SAFE_INTEGER', () => {
     expect(clampMinAndMax(1e-10)).toBe(1e-10)
-    expect(clampMinAndMax(Number.MAX_VALUE + 1)).toBe(Number.MAX_VALUE)
-    expect(clampMinAndMax(Number.MIN_VALUE - 1)).toBe(Number.MIN_VALUE)
-    expect(clampMinAndMax(Number.POSITIVE_INFINITY)).toBe(Number.MAX_VALUE)
-    expect(clampMinAndMax(Number.NEGATIVE_INFINITY)).toBe(Number.MIN_VALUE)
+    expect(clampMinAndMax(-100)).toBe(-100)
+    expect(clampMinAndMax(Number.MAX_SAFE_INTEGER + 1)).toBe(
+      Number.MAX_SAFE_INTEGER
+    )
+    expect(clampMinAndMax(Number.MIN_SAFE_INTEGER - 1)).toBe(
+      Number.MIN_SAFE_INTEGER
+    )
+    expect(clampMinAndMax(Number.POSITIVE_INFINITY)).toBe(
+      Number.MAX_SAFE_INTEGER
+    )
+    expect(clampMinAndMax(Number.NEGATIVE_INFINITY)).toBe(
+      Number.MIN_SAFE_INTEGER
+    )
   })
 })
 

--- a/packages/mymath/src/clamp.ts
+++ b/packages/mymath/src/clamp.ts
@@ -28,7 +28,7 @@ export const clamp = (value: number, range: [number, number]): number => {
  * @returns The clamped value between Number.MIN_SAFE_INTEGER and Number.MAX_SAFE_INTEGER
  */
 export const clampMinAndMax = (value: number): number => {
-  return clamp(value, [Number.MIN_VALUE, Number.MAX_VALUE])
+  return clamp(value, [Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER])
 }
 
 /**


### PR DESCRIPTION
## Summary

`clampMinAndMax` was documented as clamping to `Number.MIN_SAFE_INTEGER` and `Number.MAX_SAFE_INTEGER`, but the implementation used `Number.MIN_VALUE` and `Number.MAX_VALUE`.

`Number.MIN_VALUE` is the smallest *positive* float (~5e-324), not the most negative safe integer (-9007199254740991). As a result, any negative input to `clampMinAndMax` was incorrectly clamped to `~5e-324` rather than passed through.

`clampMinAndMaxInt` (sibling function in the same file) uses the correct constants.

## Changes

- `packages/mymath/src/clamp/index.ts`: replace `Number.MIN_VALUE` / `Number.MAX_VALUE` with `Number.MIN_SAFE_INTEGER` / `Number.MAX_SAFE_INTEGER` in `clampMinAndMax`
- `packages/mymath/src/clamp/index.spec.ts`: update the `clampMinAndMax` test to reflect the corrected contract (negative inputs now pass through; bounds are `MIN_SAFE_INTEGER` / `MAX_SAFE_INTEGER`)

## Trade-offs

This is a bug fix — the implementation diverged from its documented contract. Callers relying on the undocumented `MIN_VALUE` clamping behavior will see different results, but that behavior was always incorrect per the JSDoc.
