### PR TITLE
fix: move @kitsuyui/cipher to dependencies in bits128

### DIFF
--- a/packages/bits128/package.json
+++ b/packages/bits128/package.json
@@ -34,7 +34,7 @@
     "dist",
     "package.json"
   ],
-  "devDependencies": {
+  "dependencies": {
     "@kitsuyui/cipher": "workspace:*"
   }
 }


### PR DESCRIPTION
## Summary

`packages/bits128/src/bitShuffle.ts` imports `RijndaelSBox`, `utils`, and `xorShuffle` from `@kitsuyui/cipher`. This file is part of the public API (re-exported via `index.ts`). However, `@kitsuyui/cipher` was declared only in `devDependencies`, not `dependencies`.

This means a consumer who installs `@kitsuyui/bits128` from npm would not have `@kitsuyui/cipher` installed, causing a runtime error when calling `applySBox128bitBigintTo128bitBigint`. The monorepo workspace hides this issue because all packages are linked locally during development.

## Changes

- `packages/bits128/package.json`: move `@kitsuyui/cipher` from `devDependencies` to `dependencies`

## Trade-offs

No behavioral change. This only corrects the declared dependency graph so that consumers have `@kitsuyui/cipher` installed automatically when they install `@kitsuyui/bits128`.
