### PR TITLE
fix: harmonicMean returns NaN for empty array instead of throwing

### DIFF
--- a/packages/mymath/src/array.spec.ts
+++ b/packages/mymath/src/array.spec.ts
@@ -86,10 +86,8 @@ describe('harmonicMean', () => {
     expect(harmonicMean([1, 2, 3, 4])).toBeCloseTo(1.92)
   })
 
-  it('should return 0 for []', () => {
-    expect(() => harmonicMean([])).toThrowError(
-      'Cannot calculate harmonic mean of empty set'
-    )
+  it('should return NaN for []', () => {
+    expect(harmonicMean([])).toBeNaN()
   })
 })
 

--- a/packages/mymath/src/array.ts
+++ b/packages/mymath/src/array.ts
@@ -92,7 +92,7 @@ export const geometricMean = (values: number[]): number => {
 
 /**
  * Harmonic mean of all values in the array
- * If the array is empty, it throws an error
+ * If the array is empty, it returns NaN (harmonic mean of an empty set is undefined)
  *
  * @example
  * ```ts
@@ -104,7 +104,7 @@ export const geometricMean = (values: number[]): number => {
  */
 export const harmonicMean = (values: number[]): number => {
   const n = values.length
-  if (n === 0) throw new Error('Cannot calculate harmonic mean of empty set')
+  if (n === 0) return Number.NaN
   return n / sum(values.map((value) => 1 / value))
 }
 


### PR DESCRIPTION
## Summary

- `harmonicMean([])` previously threw `Error('Cannot calculate harmonic mean of empty set')`, making it inconsistent with other mean functions in `@kitsuyui/mymath` that return a numeric value for empty arrays.
- Changed `harmonicMean` to return `Number.NaN` when given an empty array, which is the mathematically honest representation of an undefined result.
- Updated the docstring and test to reflect the new behavior.

## Motivation

The mean functions in `packages/mymath` are designed to be interchangeable (e.g., selectable by configuration). The only function that threw for empty arrays was `harmonicMean`, breaking that assumption:

| Function | `[]` result (before) |
|---|---|
| `arithmeticMean` | `0` |
| `geometricMean` | `1` |
| `harmonicMean` | **throws** |
| `rootMeanSquare` | `0` |
| `cubicMean` | `0` |

After this change, `harmonicMean([])` returns `Number.NaN` — consistent with the others in not throwing, and honest about the result being undefined.

## Verification

- All 217 tests pass.
- `bun run lint` passes (biome check, no issues).
- `bun run typecheck` passes.
