### PR TITLE
fix: replace global Array augmentation with exported NumberArray type

### DIFF
--- a/packages/symbolic-prototype/src/index.spec.ts
+++ b/packages/symbolic-prototype/src/index.spec.ts
@@ -1,14 +1,16 @@
 import { describe, expect, it } from 'vitest'
 
-import { SymbolicPrototype } from '.'
+import { type NumberArray, SymbolicPrototype } from '.'
 
 describe('SymbolicPrototype', () => {
   it('NumberArray', () => {
     expect(SymbolicPrototype.NumberArray).toBeDefined()
     expect(SymbolicPrototype.NumberArray.scale).toBeDefined()
     const NA = SymbolicPrototype.NumberArray
-    // example usage
-    expect([1, 2, 3][NA.scale](2)).toStrictEqual([2, 4, 6])
-    expect([1, 2, 3][NA.sum]()).toBe(6)
+    // example usage — cast required since Array.prototype is augmented at runtime
+    expect(([1, 2, 3] as unknown as NumberArray)[NA.scale](2)).toStrictEqual([
+      2, 4, 6,
+    ])
+    expect(([1, 2, 3] as unknown as NumberArray)[NA.sum]()).toBe(6)
   })
 })

--- a/packages/symbolic-prototype/src/index.ts
+++ b/packages/symbolic-prototype/src/index.ts
@@ -1,5 +1,7 @@
 import { Symbols } from './number-array'
 
+export type { NumberArray } from './number-array'
+
 export const SymbolicPrototype = {
   NumberArray: Symbols,
 } as const

--- a/packages/symbolic-prototype/src/number-array/index.spec.ts
+++ b/packages/symbolic-prototype/src/number-array/index.spec.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import { Symbols } from './index'
+import { type NumberArray, Symbols } from './index'
 
 describe('NumberArray', () => {
   it('scale', () => {
-    const array: number[] = [1, 2, 3]
+    const array = [1, 2, 3] as unknown as NumberArray
     const result = array[Symbols.scale](2)
     expect(result).toEqual([2, 4, 6])
   })

--- a/packages/symbolic-prototype/src/number-array/index.ts
+++ b/packages/symbolic-prototype/src/number-array/index.ts
@@ -8,12 +8,9 @@ export const Symbols = {
   sum: Sum,
 } as const
 
-declare global {
-  // FIXME
-  interface Array<T> {
-    [Sum](this: Array<number>): number
-    [Scale](this: Array<number>, scaler: number): number[]
-  }
+export type NumberArray = Array<number> & {
+  [Sum](): number
+  [Scale](scaler: number): number[]
 }
 
 extend(Array, Scale, (array: number[], scaler: number) => {


### PR DESCRIPTION
## Summary

- Removes `declare global { interface Array<T> { [Sum], [Scale] } }` from `packages/symbolic-prototype/src/number-array/index.ts`.
- Adds an exported `NumberArray` type that carries the same symbol-keyed method signatures.
- Re-exports `NumberArray` from the package root.
- Updates tests to cast arrays to `NumberArray` explicitly where symbol-keyed access is used.

## Motivation

The `declare global` block in `number-array/index.ts` polluted the global `Array<T>` type for every consumer that imported `@kitsuyui/symbolic-prototype`, even indirectly. A `// FIXME` comment in the original code acknowledged the problem. The side effect was invisible via import linters because global augmentations don't appear in the reference graph.

The replacement approach exports `NumberArray` as an opt-in type. Consumers who need type-safe symbol-key access import and cast explicitly — making the dependency visible and the augmentation intentional.

## Changes

| File | Change |
|---|---|
| `src/number-array/index.ts` | Replace `declare global { interface Array<T> }` with `export type NumberArray` |
| `src/index.ts` | Add `export type { NumberArray }` |
| `src/number-array/index.spec.ts` | Cast to `NumberArray` before symbol access |
| `src/index.spec.ts` | Import `NumberArray`, cast for symbol access |

## Verification

- All 217 tests pass.
- `bun run lint` passes (biome, no issues).
- `bun run typecheck` passes.
