### PR TITLE
fix: add ResultDoubleFailure for failed-operation-plus-failed-rollback case

### DIFF
--- a/packages/intended-rollback/src/base.spec.ts
+++ b/packages/intended-rollback/src/base.spec.ts
@@ -112,4 +112,34 @@ describe('dummyClientIntendedRollback', () => {
       },
     })
   })
+  it('should return double failure when rollback also fails', async () => {
+    const mainError = new Error('main error')
+    const rollbackError = new Error('rollback failed')
+    const failingRollbackOuterFn = async <T>(
+      _client: unknown,
+      callback: (tran: DummyClientTransaction) => Promise<T>
+    ): Promise<T> => {
+      const tran = new DummyClientTransaction()
+      try {
+        return await callback(tran)
+      } catch (_) {
+        throw rollbackError
+      }
+    }
+    const wrapped = wrapWithRollback<unknown, DummyClientTransaction, string>(
+      failingRollbackOuterFn
+    )
+    const result = await wrapped(null, false, async () => {
+      throw mainError
+    })
+    expect(result).toEqual({
+      success: false,
+      error: mainError,
+      rollbackError: rollbackError,
+      rollback: {
+        occurred: false,
+        intended: false,
+      },
+    })
+  })
 })

--- a/packages/intended-rollback/src/base.ts
+++ b/packages/intended-rollback/src/base.ts
@@ -59,6 +59,48 @@ const createFailureResult = <TContent>(error: unknown): Result<TContent> => ({
   },
 })
 
+const createDoubleFailureResult = <TContent>(
+  error: unknown,
+  rollbackError: unknown
+): Result<TContent> => ({
+  success: false,
+  error,
+  rollbackError,
+  rollback: {
+    occurred: false,
+    intended: false,
+  },
+})
+
+// Wraps `func` to capture its error before rethrowing, allowing the caller
+// to detect whether a subsequent outer exception is a rollback failure.
+const wrapFuncWithErrorCapture =
+  <TClientTran, TContent>(
+    func: TranInnerFn<TClientTran, TContent>,
+    errors: Array<{ error: unknown }>
+  ): TranInnerFn<TClientTran, TContent> =>
+  async (something) => {
+    try {
+      return await func(something)
+    } catch (e) {
+      errors.push({ error: e })
+      throw e
+    }
+  }
+
+const resolveFromCatch = <TContent>(
+  e: unknown,
+  content: TContent | null,
+  funcErrors: Array<{ error: unknown }>
+): Result<TContent> => {
+  if (e instanceof IntendedRollback)
+    return createIntendedRollbackResult(content)
+  if (funcErrors.length > 0 && e !== funcErrors[0].error) {
+    return createDoubleFailureResult(funcErrors[0].error, e)
+  }
+  return createFailureResult(e)
+}
+
 /**
  * Handle rollback
  * @param client Client instance (i.e. database client like PrismaClient)
@@ -74,21 +116,18 @@ const handleRollback = async <TClient, TClientTran, TContent>(
   rollback: boolean
 ): Promise<Result<TContent>> => {
   let content: TContent | null = null
+  const funcErrors: Array<{ error: unknown }> = []
+  const wrappedFunc = wrapFuncWithErrorCapture(func, funcErrors)
   try {
     content = await outer(client, async (something) => {
-      const content_ = await func(something)
+      const content_ = await wrappedFunc(something)
       // keep the content prepared for intended rollback
       content = content_
-      if (rollback) {
-        throw new IntendedRollback()
-      }
+      if (rollback) throw new IntendedRollback()
       return content_
     })
     return createSuccessResult(content)
   } catch (e) {
-    if (e instanceof IntendedRollback) {
-      return createIntendedRollbackResult(content)
-    }
-    return createFailureResult(e)
+    return resolveFromCatch(e, content, funcErrors)
   }
 }

--- a/packages/intended-rollback/src/types.ts
+++ b/packages/intended-rollback/src/types.ts
@@ -7,6 +7,16 @@ interface ResultFailure {
   }
 }
 
+interface ResultDoubleFailure {
+  success: false
+  error: unknown
+  rollbackError: unknown
+  rollback: {
+    occurred: false
+    intended: false
+  }
+}
+
 interface ResultSuccess<T> {
   success: true
   content: T
@@ -27,6 +37,7 @@ interface ResultSuccessAndIntendedRollback<T> {
 
 export type Result<T> =
   | ResultFailure
+  | ResultDoubleFailure
   | ResultSuccess<T>
   | ResultSuccessAndIntendedRollback<T>
 


### PR DESCRIPTION
## Summary

- Adds `ResultDoubleFailure` to the `Result<T>` union in `packages/intended-rollback`.
- `ResultDoubleFailure` represents the state where the main operation failed **and** the rollback itself also failed — previously an inexpressible state.
- Updates `handleRollback` to detect this case and return `ResultDoubleFailure` instead of the misleading `ResultFailure` (which implied a successful rollback).
- Adds a test case that simulates rollback failure via a custom outer function.

## Motivation

The `Result<T>` union previously had three variants:

| State | `success` | `rollback.occurred` |
|---|---|---|
| `ResultSuccess` | `true` | `false` |
| `ResultSuccessAndIntendedRollback` | `true` | `true` |
| `ResultFailure` | `false` | `true` |

The variant `{ success: false, rollback.occurred: false }` — representing a double failure (operation failed **and** rollback failed) — was missing. When a rollback failed, `ResultFailure` was returned with `rollback.occurred: true`, falsely asserting that the rollback succeeded.

This is a real scenario in database transactions when network errors or timeouts occur during the rollback path after an operation failure.

## Design

Double failure is detected by comparing the error thrown by `outer` with the error captured from `func`. If they differ, `outer` threw a new error during rollback — the rollback failed.

Callers can narrow the new variant using the discriminant:
```ts
if (!result.success && !result.rollback.occurred) {
  // result is ResultDoubleFailure
  // result.error = original operation error
  // result.rollbackError = error from failed rollback
}
```

## Changes

| File | Change |
|---|---|
| `src/types.ts` | Add `ResultDoubleFailure` interface; add to `Result<T>` union |
| `src/base.ts` | Add `wrapFuncWithErrorCapture`, `resolveFromCatch`, `createDoubleFailureResult`; update `handleRollback` |
| `src/base.spec.ts` | Add double-failure test case |

## Verification

- All 218 tests pass (1 new test added).
- `bun run lint` passes (biome, no issues).
- `bun run typecheck` passes.
