### PR TITLE
fix: fail release workflow when publish fails

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,6 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
 
-    continue-on-error: true
-
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Summary
- Remove `continue-on-error: true` from `.github/workflows/release.yml` so the release workflow fails when publish fails.

## Validation
- `git diff --check`
- `actionlint .github/workflows/release.yml`
- `bun install --frozen-lockfile`
- `bun run build`
- `bun run validate`
