### PR TITLE
test(object-version-control): add automerge.spec.ts

### DIFF
--- a/packages/object-version-control/src/automerge.spec.ts
+++ b/packages/object-version-control/src/automerge.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+
+import { AutomergeResolver, createAutomergeResolver } from './automerge'
+import { ObjectVersionControl } from './ovc'
+
+describe('createAutomergeResolver', () => {
+  it('returns a function', () => {
+    const resolver = createAutomergeResolver({})
+    expect(typeof resolver).toBe('function')
+  })
+
+  it('merges two diverged branches combining non-conflicting keys', () => {
+    const ovc = ObjectVersionControl.create<Record<string, unknown>>()
+    const baseHash = ovc.commit({ key: 'value' })
+    const branch1Hash = ovc.commit({ key: 'value', attr1: 'value1' })
+    ovc.checkout(baseHash)
+    const branch2Hash = ovc.commit({ key: 'value', attr2: 'value2' })
+    ovc.checkout(baseHash)
+
+    const resolver = createAutomergeResolver({})
+    ovc.merge([branch1Hash, branch2Hash], resolver)
+
+    expect(ovc.getCurrentData()).toEqual({
+      key: 'value',
+      attr1: 'value1',
+      attr2: 'value2',
+    })
+  })
+
+  it('throws when base is null', () => {
+    const ovc = ObjectVersionControl.create<Record<string, unknown>>()
+    const hash1 = ovc.commit({ x: 1 })
+    const resolver = createAutomergeResolver({})
+    expect(() => resolver(ovc, [hash1], null)).toThrow(
+      'Base commit is required'
+    )
+  })
+})
+
+describe('AutomergeResolver', () => {
+  it('is a function', () => {
+    expect(typeof AutomergeResolver).toBe('function')
+  })
+
+  it('merges two diverged branches', () => {
+    const ovc = ObjectVersionControl.create<Record<string, unknown>>()
+    const baseHash = ovc.commit({ key: 'value' })
+    const branch1Hash = ovc.commit({ key: 'value', attr1: 'value1' })
+    ovc.checkout(baseHash)
+    const branch2Hash = ovc.commit({ key: 'value', attr2: 'value2' })
+    ovc.checkout(baseHash)
+
+    ovc.merge([branch1Hash, branch2Hash], AutomergeResolver)
+
+    expect(ovc.getCurrentData()).toEqual({
+      key: 'value',
+      attr1: 'value1',
+      attr2: 'value2',
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Add `automerge.spec.ts` to restore the missing spec file in the `object-version-control` package.

The `packages/object-version-control/src/` directory follows a consistent pattern where every source file has a sibling `.spec.ts` file. `automerge.ts` was the only exception. This PR adds the missing spec file.

## Changes

- `packages/object-version-control/src/automerge.spec.ts` (new): tests for `createAutomergeResolver` and `AutomergeResolver`
  - `createAutomergeResolver`: factory returns a function, merges two diverged branches, throws on null base
  - `AutomergeResolver`: is a function, merges two diverged branches

## Verification

```
bun test   # 34 pass, 0 fail
bun run lint    # no issues
bun run typecheck  # no errors
madge --circular  # no circular dependencies
```

## Trade-offs

Minimal change — adds the spec file only. Structural enforcement (e.g., CI check for src/spec symmetry) is deferred as a separate improvement.
