### PR TITLE
fix(mymath): replace while-loop normalization with modulo in toUnsignedRad

### DIFF
--- a/packages/mymath/src/polar/index.spec.ts
+++ b/packages/mymath/src/polar/index.spec.ts
@@ -41,6 +41,13 @@ describe('toUnsignedRad', () => {
     expect(toUnsignedRad(Number.POSITIVE_INFINITY)).toBeNaN()
     expect(toUnsignedRad(Number.NEGATIVE_INFINITY)).toBeNaN()
   })
+
+  it('should handle very large values without infinite loop', () => {
+    const large = 1e17
+    const result = toUnsignedRad(large)
+    expect(result).toBeGreaterThanOrEqual(0)
+    expect(result).toBeLessThan(2 * Math.PI)
+  })
 })
 
 describe('toSignedRad', () => {

--- a/packages/mymath/src/polar/index.ts
+++ b/packages/mymath/src/polar/index.ts
@@ -13,14 +13,8 @@ export const toUnsignedRad = (rad: number): number => {
   if (!Number.isFinite(rad)) {
     return Number.NaN
   }
-  let normalized = rad
-  while (normalized < 0) {
-    normalized += 2 * Math.PI
-  }
-  while (normalized >= 2 * Math.PI) {
-    normalized -= 2 * Math.PI
-  }
-  return normalized
+  const TWO_PI = 2 * Math.PI
+  return ((rad % TWO_PI) + TWO_PI) % TWO_PI
 }
 
 /**


### PR DESCRIPTION
## Summary

- Replace iterative while-loop normalization in `toUnsignedRad` with the O(1) double-modulo pattern `((rad % TWO_PI) + TWO_PI) % TWO_PI`
- The previous implementation could infinite-loop for inputs where `|rad| ≥ ~2.82e16`, because the ULP of such values exceeds `2π`, making each subtraction a no-op
- Adds a test case covering large-value inputs (`1e17`) to prevent regression

## Details

`toUnsignedRad` previously normalized radian values by repeatedly adding or subtracting `2π` until the result fell in `[0, 2π)`. For IEEE 754 double precision, when `|rad| ≥ 2π / 2^(-52) ≈ 2.82e16`, the ULP of `rad` is larger than `2π`, so `rad - 2π === rad` and the loop never exits.

The fix replaces both while loops with:
```ts
const TWO_PI = 2 * Math.PI
return ((rad % TWO_PI) + TWO_PI) % TWO_PI
```

The `+ TWO_PI` before the outer `%` handles negative modulo results, since JavaScript `%` returns a negative value when the dividend is negative.

## Test plan

- All existing tests continue to pass (77 tests)
- New test: `toUnsignedRad(1e17)` returns a value in `[0, 2π)` without hanging
