### PR TITLE
fix(object-version-control): restrict @automerge/automerge peer dep to v3+

### DIFF
--- a/packages/object-version-control/package.json
+++ b/packages/object-version-control/package.json
@@ -43,7 +43,7 @@
     "jsondiffpatch": "^0.7.0"
   },
   "peerDependencies": {
-    "@automerge/automerge": "^2.0.0 || ^3.0.0",
+    "@automerge/automerge": "^3.0.0",
     "jsondiffpatch": "^0.6.0 || ^0.7.0"
   }
 }


### PR DESCRIPTION
## Summary

- Narrow `peerDependencies["@automerge/automerge"]` from `"^2.0.0 || ^3.0.0"` to `"^3.0.0"` in `packages/object-version-control/package.json`

## Background

The implementation in `automerge.ts` imports `{ next as automerge }` from `@automerge/automerge`. The `next` export was introduced in Automerge v3 and does not exist in v2. The previous peer range `^2.0.0 || ^3.0.0` declared that both v2 and v3 were supported, but this was incorrect — consumers who resolved to v2 would get a runtime crash because `next` is undefined.

## Change

```diff
-    "@automerge/automerge": "^2.0.0 || ^3.0.0",
+    "@automerge/automerge": "^3.0.0",
```

## Verification

- All 217 tests pass
- No lint or format issues
- Module isolation check: 0 violations
