### PR TITLE
fix(luxon-ext): use calendar-aware diff and propagate begin locale in toHumanDurationWithDiff

### DIFF
--- a/packages/luxon-ext/src/index.spec.ts
+++ b/packages/luxon-ext/src/index.spec.ts
@@ -109,4 +109,26 @@ describe('toHumanDurationWithDiff', () => {
     expect(toHumanDurationWithDiff(begin, end)).toBe('in 1 hour, 23 minutes')
     expect(toHumanDurationWithDiff(end, begin)).toBe('1 hour, 23 minutes ago')
   })
+
+  it('should use begin locale when end has no locale', () => {
+    // begin.locale is 'ja'; end has no locale → locale should be 'ja'
+    const begin = DateTime.fromISO('2022-01-01T00:00:00Z').reconfigure({
+      locale: 'ja',
+    })
+    const end = DateTime.fromISO('2022-01-01T01:23:00Z')
+    // defaultFormatter wraps with English "in"/"ago"; duration text uses begin locale
+    expect(toHumanDurationWithDiff(begin, end)).toBe('in 1 時間、23 分')
+  })
+
+  it('should use calendar-aware diff for month-level durations', () => {
+    // Jan 1 to Mar 1 2022: exactly 2 calendar months
+    const begin = DateTime.fromISO('2022-01-01T00:00:00Z').reconfigure({
+      locale: 'en',
+    })
+    const end = DateTime.fromISO('2022-03-01T00:00:00Z').reconfigure({
+      locale: 'en',
+    })
+    // calendar-aware diff gives {months: 2, days: 0} → rounds to "2 months"
+    expect(toHumanDurationWithDiff(begin, end)).toBe('in 2 months')
+  })
 })

--- a/packages/luxon-ext/src/index.ts
+++ b/packages/luxon-ext/src/index.ts
@@ -56,8 +56,20 @@ export const toHumanDurationWithDiff = (
   opts?: TemporalToHumanDurationOptions
 ): string => {
   const temporal = end > begin ? 'future' : 'past'
-  const locale = end.locale ?? undefined
-  const duration = begin.diff(end).reconfigure({ locale })
+  const locale = begin.locale ?? end.locale ?? undefined
+  const [earlier, later] = end > begin ? [begin, end] : [end, begin]
+  const duration = later
+    .diff(earlier, [
+      'years',
+      'months',
+      'weeks',
+      'days',
+      'hours',
+      'minutes',
+      'seconds',
+      'milliseconds',
+    ])
+    .reconfigure({ locale })
   return toHumanDurationWithTemporal(duration, temporal, opts)
 }
 

--- a/packages/luxon-ext/src/rounding/index.ts
+++ b/packages/luxon-ext/src/rounding/index.ts
@@ -32,9 +32,9 @@ const roundingOptionsFromPartial = (
  * @returns
  */
 export const cleanDuration = (duration: Duration): Duration => {
-  const cleaned = duration.shiftToAll().toMillis()
-  const abs = Math.abs(cleaned)
-  return Duration.fromMillis(abs)
+  const ms = duration.as('milliseconds')
+  if (ms >= 0) return duration
+  return Duration.fromMillis(-ms)
 }
 
 const collectRoundedUnits = (


### PR DESCRIPTION
## Summary

- `toHumanDurationWithDiff` used `begin.diff(end)` which produces a milliseconds-only Duration. Switch to `later.diff(earlier, ['years', 'months', 'weeks', 'days', 'hours', 'minutes', 'seconds', 'milliseconds'])` so Luxon computes a calendar-aware breakdown from the start.
- Locale was taken from `end.locale` only. Changed to `begin.locale ?? end.locale` so the caller's primary DateTime determines the locale.
- `cleanDuration` now returns the duration unchanged when it is already positive, preserving calendar units through the rounding pipeline.

## Changes

- `packages/luxon-ext/src/index.ts`: calendar-aware diff + locale fix in `toHumanDurationWithDiff`
- `packages/luxon-ext/src/rounding/index.ts`: `cleanDuration` preserves positive calendar-unit Durations
- `packages/luxon-ext/src/index.spec.ts`: tests for locale propagation from `begin` and calendar-aware month diff

## Trade-offs

The month-rounding threshold in `constants.ts` still uses a fixed 30.4375 days/month approximation. A fully calendar-aware month boundary (e.g. 15 days in February rounding to 1 month) would require passing the reference DateTime into the rounding logic — left as a follow-up.

## Test plan

- [ ] `bun run test` passes in `packages/luxon-ext` (9 tests, 0 failures)
- [ ] `biome check` reports no issues
