### PR TITLE
Make luxon rounding thresholds units explicit

### DIFF
--- a/packages/luxon-ext/src/constants.ts
+++ b/packages/luxon-ext/src/constants.ts
@@ -1,19 +1,19 @@
-const MILLIS = 1
-const SECONDS = MILLIS * 1000
-const MINUTES = SECONDS * 60
-const HOURS = MINUTES * 60
-const DAYS = HOURS * 24
-const WEEKS = DAYS * 7
-const YEARS = DAYS * 365.25
-const MONTHS = YEARS / 12
+const MILLISECOND_MS = 1
+const SECOND_MS = MILLISECOND_MS * 1000
+const MINUTE_MS = SECOND_MS * 60
+const HOUR_MS = MINUTE_MS * 60
+const DAY_MS = HOUR_MS * 24
+const WEEK_MS = DAY_MS * 7
+const YEAR_MS = DAY_MS * 365.25
+const MONTH_MS = YEAR_MS / 12
 
-export const HALF_OF_TIME_UNITS = {
-  years: 0.5 * YEARS,
-  months: 0.5 * MONTHS,
-  weeks: 0.5 * WEEKS,
-  days: 0.5 * DAYS,
-  hours: 0.5 * HOURS,
-  minutes: 0.5 * MINUTES,
-  seconds: 0.5 * SECONDS,
-  milliseconds: 0.5 * MILLIS,
+export const HALF_OF_TIME_UNITS_MS = {
+  years: 0.5 * YEAR_MS,
+  months: 0.5 * MONTH_MS,
+  weeks: 0.5 * WEEK_MS,
+  days: 0.5 * DAY_MS,
+  hours: 0.5 * HOUR_MS,
+  minutes: 0.5 * MINUTE_MS,
+  seconds: 0.5 * SECOND_MS,
+  milliseconds: 0.5 * MILLISECOND_MS,
 } as const

--- a/packages/luxon-ext/src/rounding/index.ts
+++ b/packages/luxon-ext/src/rounding/index.ts
@@ -1,5 +1,5 @@
 import { Duration, type DurationObjectUnits } from 'luxon'
-import { HALF_OF_TIME_UNITS } from '../constants'
+import { HALF_OF_TIME_UNITS_MS } from '../constants'
 import { computeTopUnit, computeUseUnits, type TimeUnit } from '../units'
 
 type RoundingMethod = 'floor' | 'ceil' | 'round'
@@ -67,7 +67,7 @@ const shouldCarryRoundedUnit = (
     return remainMillis > 0
   }
   if (roundingMethod === 'round') {
-    return remainMillis >= HALF_OF_TIME_UNITS[roundingHigherUnit]
+    return remainMillis >= HALF_OF_TIME_UNITS_MS[roundingHigherUnit]
   }
   return false
 }


### PR DESCRIPTION
## Summary
- Rename luxon-ext millisecond threshold constants with `_MS` suffixes.
- Update rounding code to read from `HALF_OF_TIME_UNITS_MS` while preserving the existing threshold values.

## Verification
- `bun install --frozen-lockfile`
- `bun run format`
- `bun run build`
- `bun run lint`
- `bun run typecheck`
- `bun run check-module-isolation`
- `bun run validate`
- `bun run typedoc`
- `bun run test`
- `bunx madge --circular --extensions ts packages/*/src`
- `git diff --check`
