### PR TITLE
fix(intended-rollback): thread content through IntendedRollback to eliminate shared mutable closure

### DIFF
--- a/packages/intended-rollback/src/base.ts
+++ b/packages/intended-rollback/src/base.ts
@@ -1,4 +1,4 @@
-import { IntendedRollback, Unreachable } from './errors'
+import { IntendedRollback } from './errors'
 import type {
   Result,
   TranInnerFn,
@@ -35,20 +35,15 @@ const createSuccessResult = <TContent>(
 })
 
 const createIntendedRollbackResult = <TContent>(
-  content: TContent | null
-): Result<TContent> => {
-  if (content === null) {
-    throw new Unreachable('Intended rollback without content.')
-  }
-  return {
-    success: true,
-    content,
-    rollback: {
-      occurred: true,
-      intended: true,
-    },
-  }
-}
+  content: TContent
+): Result<TContent> => ({
+  success: true,
+  content,
+  rollback: {
+    occurred: true,
+    intended: true,
+  },
+})
 
 const createFailureResult = <TContent>(error: unknown): Result<TContent> => ({
   success: false,
@@ -90,11 +85,10 @@ const wrapFuncWithErrorCapture =
 
 const resolveFromCatch = <TContent>(
   e: unknown,
-  content: TContent | null,
   funcErrors: Array<{ error: unknown }>
 ): Result<TContent> => {
   if (e instanceof IntendedRollback)
-    return createIntendedRollbackResult(content)
+    return createIntendedRollbackResult(e.content as TContent)
   if (funcErrors.length > 0 && e !== funcErrors[0].error) {
     return createDoubleFailureResult(funcErrors[0].error, e)
   }
@@ -115,19 +109,18 @@ const handleRollback = async <TClient, TClientTran, TContent>(
   func: TranInnerFn<TClientTran, TContent>,
   rollback: boolean
 ): Promise<Result<TContent>> => {
-  let content: TContent | null = null
   const funcErrors: Array<{ error: unknown }> = []
   const wrappedFunc = wrapFuncWithErrorCapture(func, funcErrors)
   try {
-    content = await outer(client, async (something) => {
+    const content = await outer(client, async (something) => {
       const content_ = await wrappedFunc(something)
-      // keep the content prepared for intended rollback
-      content = content_
-      if (rollback) throw new IntendedRollback()
+      if (rollback) {
+        throw new IntendedRollback(content_)
+      }
       return content_
     })
     return createSuccessResult(content)
   } catch (e) {
-    return resolveFromCatch(e, content, funcErrors)
+    return resolveFromCatch(e, funcErrors)
   }
 }

--- a/packages/intended-rollback/src/errors.ts
+++ b/packages/intended-rollback/src/errors.ts
@@ -3,7 +3,7 @@
  * Error is needed for jumping to the catch block
  */
 export class IntendedRollback extends Error {
-  constructor() {
+  constructor(public readonly content: unknown) {
     super('Intended Rollback')
   }
 }


### PR DESCRIPTION
## Summary

`handleRollback` in `packages/intended-rollback/src/base.ts` mutated an
outer-scope `let content` variable from inside an async callback and then read
it in the `catch` block. This created an implicit sequential-invocation
assumption on `outer` (TranOuterFn): if `outer` called the callback
concurrently, skipped it, or re-threw before it ran, the catch block would
receive `null` and hit the `Unreachable` guard.

This PR removes the shared mutable variable by embedding the captured content
directly in the `IntendedRollback` exception. The catch block now reads
`e.content` instead of the outer-scope variable, making the data flow
self-contained and independent of `outer`'s invocation order.

## Changes

- `packages/intended-rollback/src/errors.ts`: Add `content: unknown` field to
  `IntendedRollback` constructor.
- `packages/intended-rollback/src/base.ts`:
  - Remove `let content: TContent | null = null` shared variable.
  - Throw `new IntendedRollback(content_)` instead of `new IntendedRollback()`.
  - Read `e.content as TContent` in the catch block.
  - Remove the now-unnecessary `null` guard in `createIntendedRollbackResult`.
  - Remove unused `Unreachable` import.

## Verification

- All 217 tests pass (`bun run test`).
- Biome format and lint: no findings (`bun run format`, `bun run lint`).
- TypeScript strict mode: no errors (`bun run typecheck`).

## Trade-offs

`IntendedRollback` constructor gains a required `content` parameter — a minor
breaking change. At v0.0.0 this is acceptable. Callers that instantiate
`IntendedRollback` directly (rather than relying on `wrapWithRollback`) will
need to pass the content value.
