### PR TITLE
fix(object-version-control): make jsondiffpatch a runtime dependency only

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -80,11 +80,9 @@
       "devDependencies": {
         "@automerge/automerge": "^3.2.0",
         "@types/node": "^24.9.2",
-        "jsondiffpatch": "^0.7.0",
       },
       "peerDependencies": {
         "@automerge/automerge": "^2.0.0 || ^3.0.0",
-        "jsondiffpatch": "^0.6.0 || ^0.7.0",
       },
     },
     "packages/string": {

--- a/packages/object-version-control/package.json
+++ b/packages/object-version-control/package.json
@@ -39,11 +39,9 @@
   },
   "devDependencies": {
     "@automerge/automerge": "^3.2.0",
-    "@types/node": "^24.9.2",
-    "jsondiffpatch": "^0.7.0"
+    "@types/node": "^24.9.2"
   },
   "peerDependencies": {
-    "@automerge/automerge": "^2.0.0 || ^3.0.0",
-    "jsondiffpatch": "^0.6.0 || ^0.7.0"
+    "@automerge/automerge": "^2.0.0 || ^3.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- Keep `jsondiffpatch` as a runtime dependency for `@kitsuyui/object-version-control`.
- Remove duplicate `jsondiffpatch` declarations from `devDependencies` and `peerDependencies`.

## Motivation
`@kitsuyui/object-version-control` imports `jsondiffpatch` internally, so consumers should receive it as a normal runtime dependency. Declaring it as both a bundled dependency and a peer dependency made the install contract ambiguous.

## Verification
- `bun install --frozen-lockfile`
- `bun run format`
- `bun run lint`
- `bun run test`
- `bun run typecheck`
- `bun run check-module-isolation`
- `bun run build`
- `bun run validate`
- `bun run typedoc`
- `bunx madge --circular --extensions ts packages/object-version-control/src`
- `git diff --check`
- `implement-validator: overall pass`
