### PR TITLE
fix(ovc): brand SyncHead to prevent arbitrary construction

### DIFF
--- a/packages/object-version-control/src/ovc.ts
+++ b/packages/object-version-control/src/ovc.ts
@@ -51,7 +51,7 @@ export class ObjectVersionControl<T> {
     const syncHead = {
       local: this.head,
       remote: ovc.head,
-    }
+    } as unknown as SyncHead
     return [ovc, syncHead]
   }
 
@@ -248,7 +248,7 @@ export class ObjectVersionControl<T> {
     return {
       local: this.head,
       remote: remoteOvc.head,
-    }
+    } as unknown as SyncHead
   }
 
   /**
@@ -279,6 +279,6 @@ export class ObjectVersionControl<T> {
     return {
       local: this.head,
       remote: remoteOvc.head,
-    }
+    } as unknown as SyncHead
   }
 }

--- a/packages/object-version-control/src/types.d.ts
+++ b/packages/object-version-control/src/types.d.ts
@@ -36,7 +36,15 @@ interface SyncItems<T> {
   snapshots: Snapshot<T>[]
 }
 
+declare const _syncHeadBrand: unique symbol
+
+/**
+ * SyncHead represents the last-known sync positions between two OVC instances.
+ * Valid SyncHead values are only produced by push(), pull(), fullClone(), and shallowClone().
+ * The opaque brand prevents construction of arbitrary SyncHead literals.
+ */
 interface SyncHead {
+  readonly [_syncHeadBrand]: undefined
   local: HashValue | null
   remote: HashValue | null
 }


### PR DESCRIPTION
## Summary

The `SyncHead` interface in `packages/object-version-control` could be constructed from arbitrary string values, bypassing the intended lifecycle contract. Valid `SyncHead` values should only come from `push()`, `pull()`, `fullClone()`, or `shallowClone()` — passing a stale or hand-crafted `SyncHead` silently causes full-history transfers instead of incremental sync.

This change adds an opaque brand via a `unique symbol` to `SyncHead`, making it a compile-time error to construct a `SyncHead` literal outside the OVC class.

## Changes

- `src/types.d.ts`: add `declare const _syncHeadBrand: unique symbol` and brand the `SyncHead` interface with `readonly [_syncHeadBrand]: undefined`
- `src/ovc.ts`: add `as unknown as SyncHead` at the three authorized construction sites (`cloneSyncItems`, `pushSyncItems`, `pullSyncItems`)

## Verification

- `bun run format`: no fixes applied
- `bun run lint`: no fixes applied
- `bun run test`: all tests pass
- `bun run typecheck`: no errors
- `madge --circular`: no circular dependencies found
