### PR TITLE
chore: add lefthook to run CI checks locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,29 @@ bun run validate
 bun run typedoc
 ```
 
+## Development
+
+Install [lefthook](https://github.com/evilmartians/lefthook) and register the Git hooks:
+
+```sh
+lefthook install
+```
+
+### Git hooks
+
+**pre-commit** — runs on every commit:
+
+- `bun run lint` — Biome linter check
+- `bun run typecheck` — TypeScript type check
+
+**pre-push** — runs on every push:
+
+- `bun run lint` — Biome linter check
+- `bun run typecheck` — TypeScript type check
+- `bun run test` — Vitest test suite with coverage
+
+These hooks bring CI feedback to your local workflow. CI still runs the full suite (including build, package export validation, and TypeDoc generation) on every pull request and push to main.
+
 ## License
 
 MIT

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,17 @@
+# Clear Git hook environment variables before running checks so nested or sibling
+# repositories are not affected: https://git-scm.com/docs/githooks
+pre-commit:
+  jobs:
+    - name: lint
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; bun run lint
+    - name: typecheck
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; bun run typecheck
+
+pre-push:
+  jobs:
+    - name: lint
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; bun run lint
+    - name: typecheck
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; bun run typecheck
+    - name: test
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; bun run test


### PR DESCRIPTION
## Summary

- Add `lefthook.yml` to mirror CI checks locally as Git hooks
- Add `## Development` section to `README.md` documenting how to install and use the hooks
- CI workflows are unchanged

## What the hooks run

**pre-commit:** `bun run lint` (Biome), `bun run typecheck` (TypeScript)

**pre-push:** `bun run lint`, `bun run typecheck`, `bun run test` (Vitest with coverage)

These mirror the same checks that CI runs on every pull request and push to main, bringing feedback earlier in the development cycle. CI still runs the full suite (build, package export validation, TypeDoc generation, etc.).
