### PR TITLE
test: enforce Vitest coverage thresholds

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -22,6 +22,12 @@ export default defineConfig({
       include: ['**/src/**/*.ts'],
       exclude: ['**/src/**/*.spec.ts'],
       reporter: ['text', 'html', 'lcov'],
+      thresholds: {
+        statements: 95,
+        branches: 85,
+        functions: 95,
+        lines: 95,
+      },
     },
   },
   /**


### PR DESCRIPTION
## Summary
- Add global Vitest coverage thresholds for statements, branches, functions, and lines in `vitest.config.ts`.
- Set the initial thresholds below the current coverage baseline so coverage regressions fail without breaking the existing test suite.

## Verification
- bun install --frozen-lockfile
- git diff --check
- bun run lint
- bun run typecheck
- bun run check-module-isolation
- bun run build
- bun run validate
- bun run typedoc
- bun run test

## Trade-offs
- These are initial global thresholds; package-specific thresholds can be added later as coverage expectations become more granular.
