### PR TITLE
docs: add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security Policy
+
+## Supported Scope
+
+This policy applies to packages maintained in this repository and published from
+the `packages/*` workspaces.
+
+Unless a package documents a separate policy, security fixes are considered for
+the latest published version of each package.
+
+## Reporting a Vulnerability
+
+Please do not open a public issue for suspected vulnerabilities.
+
+Use GitHub's private vulnerability reporting flow when it is available for this
+repository. If that private flow is unavailable, email the maintainer listed in
+the package metadata at `kitsuyui@kitsuyui.com`.
+
+Include the affected package name, affected version, impact, and enough
+reproduction context for the maintainer to investigate safely. Do not include
+secrets or unrelated private data in the report.
+
+The maintainer will review the report and coordinate remediation or disclosure
+steps as appropriate.


### PR DESCRIPTION
Summary
- Add SECURITY.md for packages maintained in this repository.
- Document how to report suspected vulnerabilities without opening public issues.
- Clarify the supported scope for latest published package versions.

Verification
- git diff --no-index --check /dev/null SECURITY.md
- typos SECURITY.md
- go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color
- bun install --frozen-lockfile
- bun run lint
- bun run typecheck
- bun run check-module-isolation
- bun run build
- bun run validate
- bun run test
- bun run typedoc
- collateral check: clean
