### PR TITLE
fix(incremental-color-palette): collapse duplicate wave converters

### DIFF
--- a/packages/incremental-color-palette/src/colorPalette.spec.ts
+++ b/packages/incremental-color-palette/src/colorPalette.spec.ts
@@ -42,6 +42,23 @@ describe('uintToRGB', () => {
     )
     expect(colors).toHaveLength(256)
   })
+
+  it('applies saturation and brightness parameters independently', () => {
+    const saturationParameter = {
+      range: [0.5, 0.5],
+      frequency: 1,
+      phase: 0,
+    } as WaveParameter
+    const brightnessParameter = {
+      range: [0.25, 0.25],
+      frequency: 1,
+      phase: 0,
+    } as WaveParameter
+
+    expect(uintToRGB(0, saturationParameter, brightnessParameter)).toEqual([
+      64, 32, 32,
+    ])
+  })
 })
 
 describe('waveInRange', () => {

--- a/packages/incremental-color-palette/src/colorPalette.ts
+++ b/packages/incremental-color-palette/src/colorPalette.ts
@@ -27,8 +27,8 @@ export const uintToHSV = (
   brightnessParameter: WaveParameter
 ): HSV0to1 => {
   const hue = uintToHue(n)
-  const saturation = uintToSaturation(n, saturationParameter)
-  const brightness = uintToBrightness(n, brightnessParameter)
+  const saturation = uintToWaveComponent(n, saturationParameter)
+  const brightness = uintToWaveComponent(n, brightnessParameter)
   return [hue, saturation, brightness]
 }
 
@@ -39,21 +39,7 @@ const uintToHue = (n: uint0toInf): number => {
   return a_n(n)
 }
 
-/**
- * Convert a given number to a saturation value in this color palette.
- */
-export const uintToSaturation = (
-  n: uint0toInf,
-  parameter: WaveParameter
-): number0to1 => {
-  const rad = uintToRadians(n)
-  return waveInRange(rad, parameter)
-}
-
-/**
- * Convert a given number to a brightness value in this color palette.
- */
-export const uintToBrightness = (
+const uintToWaveComponent = (
   n: uint0toInf,
   parameter: WaveParameter
 ): number0to1 => {


### PR DESCRIPTION
## Summary
- replace duplicate saturation and brightness converter exports with a shared internal wave component helper
- keep `uintToHSV` applying the saturation and brightness parameters explicitly at the call site
- add a regression test for independent saturation and brightness parameters through `uintToRGB`

## Validation
- `bun install --frozen-lockfile`
- `bun run lint`
- `bun run typecheck`
- `bun run check-module-isolation`
- `bun run build`
- `bun run validate`
- `bun run typedoc`
- `bun run test`
- `bunx madge --circular --extensions ts,tsx packages/incremental-color-palette/src`