### PR TITLE
fix(incremental-color-palette): write example output atomically

### DIFF
--- a/packages/incremental-color-palette/examples/example.ts
+++ b/packages/incremental-color-palette/examples/example.ts
@@ -1,4 +1,5 @@
-import { writeFileSync } from 'node:fs'
+import { mkdtempSync, renameSync, rmSync, writeFileSync } from 'node:fs'
+import { basename, dirname, join } from 'node:path'
 import { uintToRGB, type WaveParameter } from '../src/'
 
 const main = () => {
@@ -17,7 +18,7 @@ const main = () => {
   )
   const html = colorsToHtml(colors)
 
-  writeFileSync('example.html', html)
+  writeFileAtomically('example.html', html)
 }
 
 const colorsToHtml = (colors: [number, number, number][]) => {
@@ -26,6 +27,20 @@ const colorsToHtml = (colors: [number, number, number][]) => {
       return `<div style="background-color: rgb(${r}, ${g}, ${b}); width: 100px; height: 100px; display: inline-block;"></div>`
     })
     .join('')
+}
+
+const writeFileAtomically = (targetPath: string, content: string) => {
+  const targetDir = dirname(targetPath)
+  const targetBase = basename(targetPath)
+  const tempDir = mkdtempSync(join(targetDir, `.${targetBase}.tmp-`))
+  const tempPath = join(tempDir, targetBase)
+
+  try {
+    writeFileSync(tempPath, content)
+    renameSync(tempPath, targetPath)
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true })
+  }
 }
 
 main()


### PR DESCRIPTION
## Summary

- publish the incremental-color-palette example output through a temporary file and atomic rename
- create the temporary file beside `example.html` so the rename stays on the same filesystem
- clean up the temporary directory after success or failure

## Validation

- `bun install --frozen-lockfile`
- `bunx biome check packages/incremental-color-palette/examples/example.ts`
- `bun run typecheck`
- `bun run check-module-isolation`
- `bun run build`
- `bun run validate`
- `bun run typedoc`
- `bun run test`
- `bunx madge --circular --extensions ts,tsx packages/incremental-color-palette/src`
- `git diff --check`

Note: `bun run lint` cannot complete in this local checkout because an existing `.tmp/worktrees/.../biome.json` nested root configuration is present outside this PR's diff. The changed file passed targeted Biome checking.
