### PR TITLE
Parallelize independent workflow checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,17 +51,21 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Lint
-        run: bun run lint
+      - parallel:
+          - name: Lint
+            run: bun run lint
 
-      - name: Typecheck
-        run: bun run typecheck
+          - name: Typecheck
+            run: bun run typecheck
 
-      - name: Check module isolation
-        run: bun run check-module-isolation
+          - name: Check module isolation
+            run: bun run check-module-isolation
 
-      - name: Build
-        run: bun run build
+          - name: Build
+            run: bun run build
+
+          - name: Test
+            run: bun run test
 
       - name: Measure build size
         if: matrix.node-version == '24.x'
@@ -74,6 +78,3 @@ jobs:
 
       - name: Typedoc build
         run: bun run typedoc
-
-      - name: Test
-        run: bun run test


### PR DESCRIPTION
## Summary
- Run independent lint, type-check, module-isolation, build, and test steps through a GitHub Actions `parallel` group.
- Keep build-size measurement, package export validation, and typedoc generation sequential after the parallel group.

## Verification
- Parsed the updated workflow as YAML.
- `bun run lint`
- `bun run typecheck`
- `bun run check-module-isolation`
- `bun run build`
- `bun run test`
- `bun run validate`
- `bun run typedoc`
