### PR TITLE
Guard push/pull against stale sync heads

### DIFF
--- a/packages/object-version-control/src/ovc.spec.ts
+++ b/packages/object-version-control/src/ovc.spec.ts
@@ -148,6 +148,34 @@ describe('ObjectVersionControl', () => {
     })
   })
 
+  it('should reject push when the remote head diverged after the last sync', () => {
+    const ovc1 = ObjectVersionControl.create()
+    ovc1.commit({ key: 'base' })
+    const [ovc2, syncState] = ovc1.fullClone()
+
+    ovc1.commit({ key: 'local change' })
+    ovc2.commit({ key: 'remote change' })
+
+    expect(() => ovc1.push(ovc2, syncState)).toThrow(
+      /Cannot push: remote HEAD changed since last sync/
+    )
+    expect(ovc2.getCurrentData()).toEqual({ key: 'remote change' })
+  })
+
+  it('should reject pull when the local head diverged after the last sync', () => {
+    const ovc1 = ObjectVersionControl.create()
+    ovc1.commit({ key: 'base' })
+    const [ovc2, syncState] = ovc1.fullClone()
+
+    ovc1.commit({ key: 'remote change' })
+    ovc2.commit({ key: 'local change' })
+
+    expect(() => ovc2.pull(ovc1, syncState)).toThrow(
+      /Cannot pull: local HEAD changed since last sync/
+    )
+    expect(ovc2.getCurrentData()).toEqual({ key: 'local change' })
+  })
+
   it('should throw an error when checking out a non-existent commit', () => {
     const ovc = ObjectVersionControl.create()
     expect(() => ovc.checkout('non-existent')).toThrow()

--- a/packages/object-version-control/src/ovc.ts
+++ b/packages/object-version-control/src/ovc.ts
@@ -8,6 +8,7 @@ type MergeResolver<T> = (
 ) => T
 
 type CloneResult<T> = [ObjectVersionControl<T>, SyncHead]
+type SyncDirection = 'push' | 'pull'
 
 /**
  * ObjectVersionControl class
@@ -227,12 +228,26 @@ export class ObjectVersionControl<T> {
     return this.base.getSyncItemsBetween(target, base)
   }
 
+  private assertExpectedHead(
+    direction: SyncDirection,
+    role: 'local' | 'remote',
+    actual: HashValue | null,
+    expected: HashValue | null
+  ): void {
+    if (actual === expected) return
+    throw new Error(
+      `Cannot ${direction}: ${role} HEAD changed since last sync (expected ${expected ?? 'null'}, got ${actual ?? 'null'}). Refresh sync state or merge before retrying.`
+    )
+  }
+
   /**
-   * Push commits and snapshots to another repository by last known commit hash
+   * Push commits and snapshots to another repository when the remote HEAD still
+   * matches the last synchronized position.
    * @param remoteOvc Another ObjectVersionControl instance
    * @param syncHead The last known commit hash
    */
   push(remoteOvc: ObjectVersionControl<T>, syncHead: SyncHead): SyncHead {
+    this.assertExpectedHead('push', 'remote', remoteOvc.head, syncHead.remote)
     const syncItems = this.getAfterKnownHeadSyncItems(syncHead.remote)
     return this.pushSyncItems(remoteOvc, syncItems)
   }
@@ -259,11 +274,13 @@ export class ObjectVersionControl<T> {
   }
 
   /**
-   * Pull commits and snapshots from another repository by last known commit hash
+   * Pull commits and snapshots from another repository when the local HEAD still
+   * matches the last synchronized position.
    * @param remoteOvc Another ObjectVersionControl instance
    * @param syncHead
    */
   pull(remoteOvc: ObjectVersionControl<T>, syncHead: SyncHead): SyncHead {
+    this.assertExpectedHead('pull', 'local', this.head, syncHead.local)
     const syncItems = remoteOvc.getAfterKnownHeadSyncItems(syncHead.local)
     return this.pullSyncItems(remoteOvc, syncItems)
   }


### PR DESCRIPTION
## Summary

Guard push/pull against stale sync heads

Reject push when the remote HEAD no longer matches the last synchronized
remote position, and reject pull when the local HEAD no longer matches the
last synchronized local position. Keep the existing fast-forward behavior for
valid sync heads, and add regression tests that expose the previously silent
overwrite when both sides commit after cloning.

## Chosen fix

- approach: surface-fast-forward-guard
This is the smallest safe fix because it stops the silent HEAD overwrite
named in the finding without redesigning the synchronization model,
removing public API, or inventing automatic merge semantics. The package
already has merge support, but choosing when and how `push`/`pull` should
merge is a larger behavioral decision than this finding requires;
rejecting stale or divergent sync attempts preserves existing
fast-forward behavior while making the state machine explicit.