### PR TITLE
fix(object-version-control): make LWW merges deterministic on timestamp ties

### DIFF
--- a/packages/object-version-control/src/merge.spec.ts
+++ b/packages/object-version-control/src/merge.spec.ts
@@ -1,10 +1,33 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { AutomergeResolver } from './automerge'
 import { mergeResolvers } from './merge'
 import { ObjectVersionControl } from './ovc'
 
+const getExpectedLWWData = (
+  commitHash2: string,
+  commitHash3: string,
+  ovc: ObjectVersionControl<{ key: string; attr1?: string; attr2?: string }>
+) => {
+  const commit2 = ovc.getCommit(commitHash2)
+  const commit3 = ovc.getCommit(commitHash3)
+
+  if (commit2.timestamp > commit3.timestamp) {
+    return { key: 'value', attr1: 'value1' }
+  }
+  if (commit3.timestamp > commit2.timestamp) {
+    return { key: 'value', attr2: 'value2' }
+  }
+  return commitHash2.localeCompare(commitHash3) > 0
+    ? { key: 'value', attr1: 'value1' }
+    : { key: 'value', attr2: 'value2' }
+}
+
 describe('ObjectVersionControl', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   it('should merge commits', () => {
     const ovc = ObjectVersionControl.create()
     const commitHash1 = ovc.commit({ key: 'value' })
@@ -21,9 +44,30 @@ describe('ObjectVersionControl', () => {
     })
 
     ovc.merge([commitHash2, commitHash3], mergeResolvers.LWW)
-    expect(ovc.getCurrentData()).toBeOneOf([
-      { key: 'value', attr1: 'value1' },
-      { key: 'value', attr2: 'value2' },
-    ])
+    expect(ovc.getCurrentData()).toEqual(
+      getExpectedLWWData(commitHash2, commitHash3, ovc)
+    )
+  })
+
+  it('uses commit hash as a deterministic tie-breaker for LWW', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1234567890)
+
+    const ovc = ObjectVersionControl.create()
+    const baseHash = ovc.commit({ key: 'value' })
+    const commitHash2 = ovc.commit({ key: 'value', attr1: 'value1' })
+    ovc.checkout(baseHash)
+    const commitHash3 = ovc.commit({ key: 'value', attr2: 'value2' })
+
+    const expectedData =
+      commitHash2.localeCompare(commitHash3) > 0
+        ? { key: 'value', attr1: 'value1' }
+        : { key: 'value', attr2: 'value2' }
+
+    ovc.merge([commitHash2, commitHash3], mergeResolvers.LWW)
+    expect(ovc.getCurrentData()).toEqual(expectedData)
+
+    ovc.checkout(baseHash)
+    ovc.merge([commitHash3, commitHash2], mergeResolvers.LWW)
+    expect(ovc.getCurrentData()).toEqual(expectedData)
   })
 })

--- a/packages/object-version-control/src/merge.ts
+++ b/packages/object-version-control/src/merge.ts
@@ -1,9 +1,20 @@
 import type { ObjectVersionControl } from './ovc'
 import type { HashValue } from './types'
 
+const compareCommitsByLWW = (
+  left: { timestamp: number; hash: HashValue },
+  right: { timestamp: number; hash: HashValue }
+): number => {
+  const timestampOrder = right.timestamp - left.timestamp
+  if (timestampOrder !== 0) return timestampOrder
+  return right.hash.localeCompare(left.hash)
+}
+
 /**
  * Merge the targets with the Last-Writer-Wins strategy
  * The latest commit is selected as the winner.
+ * Commits with the same timestamp fall back to commit hash order so the
+ * result converges regardless of target array order.
  * All other commits are discarded.
  * @param ovc
  * @param targets
@@ -16,7 +27,7 @@ const LWWMergeResolver = <T>(
 ): T => {
   if (targets.length === 0) throw new Error('No targets to merge')
   const commits = targets.map((hash) => ovc.getCommit(hash))
-  commits.sort((a, b) => b.timestamp - a.timestamp)
+  commits.sort(compareCommitsByLWW)
   const latestCommit = commits[0]
   return ovc.getSnapshotData(latestCommit.snapshotHash)
 }


### PR DESCRIPTION
## Summary
- make LWW choose a stable winner when commits share the same timestamp
- add a regression test that proves merge order no longer changes the result

## Why
Last-writer-wins merges were only ordered by timestamp. When concurrent commits landed in the same millisecond, the winner depended on the input target order instead of converging on a single result.

## Validation
- bunx biome check --write packages/object-version-control/src/merge.ts packages/object-version-control/src/merge.spec.ts
- bun run typecheck
- bun run test
- (cd packages/object-version-control && bun run build)
- (cd packages/object-version-control && bun run validate)
