### PR TITLE
ci: surface OSV scan results through code scanning

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,16 +13,21 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 permissions:
+  actions: read
   contents: read
+  security-events: write
 
 jobs:
-  osv-scan:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+  osv-scan-pr:
+    if: github.event_name == 'pull_request'
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+    with:
+      scan-args: |-
+        --lockfile=bun.lock
 
-      - name: Scan for vulnerabilities
-        uses: google/osv-scanner-action/osv-scanner-action@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
-        with:
-          scan-args: |-
-            --lockfile=bun.lock
+  osv-scan-default-branch:
+    if: github.event_name != 'pull_request'
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+    with:
+      scan-args: |-
+        --lockfile=bun.lock


### PR DESCRIPTION
## Summary

- switch `security.yml` to the official OSV reusable workflows for pull requests and for `main` or scheduled scans
- upload OSV SARIF results to GitHub code scanning so scheduled findings are tracked in the repository security surface
- keep the existing `bun.lock` scan target and pinned `v2.3.8` release commit

## Why

The scheduled `osv-scan` run on July 27, 2026 failed on `bun.lock` vulnerabilities, but the repository workflow only surfaced that as a failed job. This change keeps the scan failing when vulnerabilities exist while adding repository-native tracking through GitHub code scanning instead of relying on a silent red scheduled check.

## Verification

- `bunx actionlint .github/workflows/security.yml`
- `bun run lint`
- `bun run test`
